### PR TITLE
Create DesignToro multi-page site

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -1,0 +1,773 @@
+:root {
+    --color-bg: #ffffff;
+    --color-text: #1d1d1f;
+    --color-muted: #6e6e73;
+    --color-accent: #0071e3;
+    --color-accent-soft: rgba(0, 113, 227, 0.12);
+    --color-border: rgba(29, 29, 31, 0.08);
+    --color-card: rgba(255, 255, 255, 0.8);
+    --shadow-soft: 0 20px 45px rgba(15, 15, 15, 0.08);
+    --max-width: 1200px;
+}
+
+* {
+    box-sizing: border-box;
+}
+
+html {
+    font-family: 'Inter', sans-serif;
+    color: var(--color-text);
+    background: var(--color-bg);
+    scroll-behavior: smooth;
+}
+
+body {
+    margin: 0;
+    min-height: 100vh;
+    background: var(--color-bg);
+}
+
+body.no-js .nav-toggle {
+    display: none;
+}
+
+a {
+    color: inherit;
+    text-decoration: none;
+}
+
+a:hover,
+a:focus {
+    color: var(--color-accent);
+}
+
+img,
+video {
+    max-width: 100%;
+    display: block;
+}
+
+.container {
+    width: min(100% - 3rem, var(--max-width));
+    margin-inline: auto;
+}
+
+.container.narrow {
+    max-width: 720px;
+    text-align: center;
+}
+
+.btn {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    gap: 0.5rem;
+    border-radius: 999px;
+    padding: 0.85rem 1.6rem;
+    font-weight: 600;
+    letter-spacing: 0.01em;
+    transition: transform 0.25s ease, box-shadow 0.25s ease, background 0.25s ease, color 0.25s ease;
+    border: none;
+    cursor: pointer;
+    font-size: 1rem;
+}
+
+.btn-accent {
+    background: var(--color-accent);
+    color: #fff;
+    box-shadow: 0 12px 30px rgba(0, 113, 227, 0.25);
+}
+
+.btn-accent:hover,
+.btn-accent:focus {
+    transform: translateY(-2px);
+    box-shadow: 0 20px 45px rgba(0, 113, 227, 0.35);
+}
+
+.btn-secondary {
+    background: rgba(0, 113, 227, 0.08);
+    color: var(--color-accent);
+}
+
+.btn-secondary:hover,
+.btn-secondary:focus {
+    background: rgba(0, 113, 227, 0.16);
+}
+
+.btn-ghost {
+    background: transparent;
+    color: var(--color-text);
+    border: 1px solid var(--color-border);
+}
+
+.btn-ghost:hover,
+.btn-ghost:focus {
+    border-color: var(--color-accent);
+    color: var(--color-accent);
+}
+
+.link-arrow {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.5rem;
+    color: var(--color-accent);
+    font-weight: 500;
+}
+
+.link-arrow::after {
+    content: '→';
+    transition: transform 0.2s ease;
+}
+
+.link-arrow:hover::after,
+.link-arrow:focus::after {
+    transform: translateX(4px);
+}
+
+.site-header {
+    position: sticky;
+    top: 0;
+    backdrop-filter: saturate(150%) blur(20px);
+    background: rgba(255, 255, 255, 0.85);
+    z-index: 1000;
+    border-bottom: 1px solid var(--color-border);
+}
+
+.header-container {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: 1rem 0;
+    gap: 1.5rem;
+}
+
+.logo span,
+.footer-logo {
+    font-weight: 700;
+    font-size: 1.25rem;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+}
+
+.main-nav {
+    position: relative;
+}
+
+.nav-toggle {
+    background: none;
+    border: none;
+    width: 2.5rem;
+    height: 2.5rem;
+    border-radius: 999px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    cursor: pointer;
+}
+
+.sr-only {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    padding: 0;
+    margin: -1px;
+    overflow: hidden;
+    clip: rect(0, 0, 0, 0);
+    white-space: nowrap;
+    border: 0;
+}
+
+.nav-toggle-bar,
+.nav-toggle-bar::before,
+.nav-toggle-bar::after {
+    content: '';
+    display: block;
+    width: 1.25rem;
+    height: 2px;
+    background: var(--color-text);
+    transition: transform 0.3s ease, opacity 0.3s ease;
+}
+
+.nav-toggle-bar::before {
+    transform: translateY(-6px);
+}
+
+.nav-toggle-bar::after {
+    transform: translateY(6px);
+}
+
+.nav-links {
+    list-style: none;
+    display: flex;
+    gap: 1.5rem;
+    margin: 0;
+    padding: 0;
+}
+
+.nav-link {
+    font-weight: 500;
+    padding: 0.5rem 0;
+    position: relative;
+}
+
+.nav-link::after {
+    content: '';
+    position: absolute;
+    left: 0;
+    bottom: 0;
+    width: 100%;
+    height: 2px;
+    background: var(--color-accent);
+    transform: scaleX(0);
+    transform-origin: right;
+    transition: transform 0.25s ease;
+}
+
+.nav-link:hover::after,
+.nav-link:focus::after {
+    transform: scaleX(1);
+    transform-origin: left;
+}
+
+.hero {
+    padding: 6rem 0 4rem;
+}
+
+.hero-content {
+    display: grid;
+    gap: 3rem;
+    align-items: center;
+}
+
+.hero-text h1 {
+    font-size: clamp(2.5rem, 5vw, 3.75rem);
+    line-height: 1.1;
+    margin-bottom: 1.5rem;
+}
+
+.hero-text p {
+    color: var(--color-muted);
+    font-size: 1.1rem;
+    max-width: 560px;
+}
+
+.eyebrow {
+    text-transform: uppercase;
+    letter-spacing: 0.12em;
+    color: var(--color-muted);
+    font-size: 0.85rem;
+    margin-bottom: 1rem;
+}
+
+.hero-actions {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 1rem;
+    margin-top: 2rem;
+}
+
+.hero-media {
+    min-height: 320px;
+    border-radius: 28px;
+    overflow: hidden;
+    background: linear-gradient(135deg, rgba(0, 113, 227, 0.2), rgba(0, 113, 227, 0));
+    position: relative;
+}
+
+.media-placeholder {
+    width: 100%;
+    height: 100%;
+    display: grid;
+    place-items: center;
+    font-weight: 600;
+    color: var(--color-muted);
+}
+
+.stats {
+    padding: 3rem 0;
+}
+
+.stats-grid {
+    display: grid;
+    gap: 1.5rem;
+    grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+}
+
+.stat-card {
+    padding: 2rem;
+    border-radius: 24px;
+    background: var(--color-card);
+    box-shadow: var(--shadow-soft);
+    text-align: center;
+}
+
+.reveal {
+    opacity: 0;
+    transform: translateY(30px);
+    transition: opacity 0.6s ease, transform 0.6s ease;
+}
+
+.reveal.in-view {
+    opacity: 1;
+    transform: translateY(0);
+}
+
+.stat-value {
+    font-size: 2.25rem;
+    font-weight: 700;
+    display: block;
+}
+
+.stat-label {
+    color: var(--color-muted);
+}
+
+.service-grid {
+    display: grid;
+    gap: 2rem;
+    grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+    margin-top: 3rem;
+}
+
+.service-card {
+    padding: 2.5rem 2rem;
+    border-radius: 24px;
+    background: var(--color-card);
+    box-shadow: var(--shadow-soft);
+    display: flex;
+    flex-direction: column;
+    gap: 1.5rem;
+}
+
+.service-card p {
+    color: var(--color-muted);
+}
+
+.service-icon {
+    width: 64px;
+    height: 64px;
+    border-radius: 20px;
+    background: var(--color-accent-soft);
+    display: grid;
+    place-items: center;
+    color: var(--color-accent);
+    font-weight: 600;
+}
+
+.portfolio-preview {
+    padding: 4rem 0;
+}
+
+.section-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    gap: 1rem;
+    flex-wrap: wrap;
+}
+
+.portfolio-grid {
+    margin-top: 2.5rem;
+    display: grid;
+    gap: 1.5rem;
+    grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+}
+
+.portfolio-card {
+    position: relative;
+    border-radius: 24px;
+    overflow: hidden;
+    background: #f2f2f7;
+    min-height: 220px;
+}
+
+.portfolio-media {
+    height: 100%;
+    display: grid;
+    place-items: center;
+    font-weight: 600;
+    color: var(--color-muted);
+}
+
+.portfolio-overlay {
+    position: absolute;
+    inset: 0;
+    background: linear-gradient(180deg, transparent, rgba(0, 0, 0, 0.65));
+    color: #fff;
+    padding: 1.5rem;
+    display: flex;
+    flex-direction: column;
+    justify-content: flex-end;
+    opacity: 0;
+    transition: opacity 0.3s ease;
+}
+
+.portfolio-card:hover .portfolio-overlay,
+.portfolio-card:focus-within .portfolio-overlay {
+    opacity: 1;
+}
+
+.principles {
+    padding: 4rem 0;
+}
+
+.principles-grid {
+    display: grid;
+    gap: 3rem;
+    grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+}
+
+.principles-list {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    display: grid;
+    gap: 2rem;
+}
+
+.principles-list p {
+    color: var(--color-muted);
+}
+
+.cta-final,
+.cta-banner {
+    padding: 4rem 0;
+}
+
+.cta-content,
+.cta-inline {
+    border-radius: 28px;
+    background: linear-gradient(135deg, rgba(0, 113, 227, 0.1), rgba(0, 113, 227, 0));
+    padding: clamp(2.5rem, 4vw, 4rem);
+    display: flex;
+    flex-direction: column;
+    gap: 1.5rem;
+    align-items: flex-start;
+}
+
+.page-hero {
+    padding: 5rem 0 3rem;
+}
+
+.service-grid.detailed {
+    margin-top: 4rem;
+}
+
+.service-benefits {
+    margin: 0;
+    padding-left: 1.2rem;
+    display: grid;
+    gap: 0.75rem;
+    color: var(--color-muted);
+}
+
+.process-grid {
+    display: grid;
+    gap: 2.5rem;
+    grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+    align-items: start;
+}
+
+.process-steps {
+    margin: 0;
+    padding-left: 1.1rem;
+    display: grid;
+    gap: 1.5rem;
+}
+
+.process-steps h3 {
+    margin: 0 0 0.5rem;
+}
+
+.pricing {
+    padding: 4rem 0;
+}
+
+.pricing-grid {
+    display: grid;
+    gap: 2rem;
+    grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+}
+
+.pricing-card {
+    position: relative;
+    padding: 2.5rem 2rem;
+    border-radius: 24px;
+    background: var(--color-card);
+    box-shadow: var(--shadow-soft);
+    display: flex;
+    flex-direction: column;
+    gap: 1.5rem;
+}
+
+.pricing-card ul {
+    margin: 0;
+    padding-left: 1.2rem;
+    color: var(--color-muted);
+    display: grid;
+    gap: 0.75rem;
+}
+
+.pricing-card .badge {
+    position: absolute;
+    top: 1.5rem;
+    right: 1.5rem;
+    background: var(--color-accent);
+    color: #fff;
+    font-size: 0.75rem;
+    padding: 0.35rem 0.8rem;
+    border-radius: 999px;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+}
+
+.pricing-card.popular {
+    border: 1px solid rgba(0, 113, 227, 0.4);
+    transform: translateY(-10px);
+}
+
+.special-offer {
+    padding: 4rem 0;
+}
+
+.special-grid {
+    display: flex;
+    flex-direction: column;
+    gap: 1.5rem;
+    border-radius: 24px;
+    background: linear-gradient(120deg, rgba(0, 113, 227, 0.15), rgba(0, 113, 227, 0));
+    padding: clamp(2.5rem, 4vw, 3.5rem);
+}
+
+.portfolio-filters {
+    padding: 1rem 0 0;
+}
+
+.filter-buttons {
+    display: flex;
+    gap: 1rem;
+    flex-wrap: wrap;
+    justify-content: center;
+}
+
+.filter-button {
+    border: none;
+    background: rgba(0, 0, 0, 0.04);
+    color: var(--color-text);
+    padding: 0.65rem 1.6rem;
+    border-radius: 999px;
+    cursor: pointer;
+    transition: background 0.2s ease, color 0.2s ease;
+}
+
+.filter-button.is-active,
+.filter-button:hover,
+.filter-button:focus {
+    background: var(--color-accent);
+    color: #fff;
+}
+
+.portfolio-masonry {
+    margin-top: 3rem;
+    display: grid;
+    gap: 1.5rem;
+    grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+}
+
+.portfolio-item {
+    border-radius: 24px;
+    overflow: hidden;
+    background: #f2f2f7;
+    min-height: 220px;
+    display: flex;
+    flex-direction: column;
+    justify-content: space-between;
+}
+
+.portfolio-details {
+    padding: 1.5rem;
+}
+
+.contact-hero {
+    padding: 5rem 0;
+}
+
+.contact-grid {
+    display: grid;
+    gap: 3rem;
+    grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+    align-items: start;
+}
+
+.contact-details {
+    list-style: none;
+    margin: 2rem 0 0;
+    padding: 0;
+    display: grid;
+    gap: 1rem;
+    color: var(--color-muted);
+}
+
+.contact-form {
+    border-radius: 24px;
+    padding: 2.5rem;
+    background: var(--color-card);
+    box-shadow: var(--shadow-soft);
+    display: grid;
+    gap: 1.5rem;
+}
+
+.form-group {
+    display: grid;
+    gap: 0.5rem;
+}
+
+.form-group label {
+    font-weight: 500;
+}
+
+.form-group input,
+.form-group textarea {
+    padding: 0.85rem 1rem;
+    border-radius: 16px;
+    border: 1px solid var(--color-border);
+    font-size: 1rem;
+    font-family: inherit;
+    background: rgba(255, 255, 255, 0.9);
+}
+
+.form-group textarea {
+    resize: vertical;
+    min-height: 150px;
+}
+
+.form-group input:focus,
+.form-group textarea:focus {
+    outline: 2px solid rgba(0, 113, 227, 0.2);
+}
+
+.form-feedback {
+    border-radius: 16px;
+    padding: 1rem 1.25rem;
+    font-weight: 500;
+}
+
+.form-feedback.success {
+    background: rgba(46, 204, 113, 0.15);
+    color: #1e8449;
+}
+
+.form-feedback.error {
+    background: rgba(231, 76, 60, 0.12);
+    color: #c0392b;
+}
+
+.honeypot {
+    position: absolute;
+    left: -9999px;
+    opacity: 0;
+    visibility: hidden;
+    height: 0;
+    width: 0;
+}
+
+.site-footer {
+    margin-top: 6rem;
+    background: #f5f5f7;
+    color: var(--color-text);
+}
+
+.footer-grid {
+    display: grid;
+    gap: 2.5rem;
+    grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+    padding: 4rem 0;
+}
+
+.footer-column h3 {
+    margin-bottom: 1rem;
+}
+
+.footer-column ul {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    display: grid;
+    gap: 0.75rem;
+    color: var(--color-muted);
+}
+
+.social-links a {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.5rem;
+}
+
+.footer-bottom {
+    border-top: 1px solid rgba(0, 0, 0, 0.08);
+    text-align: center;
+    padding: 1.5rem 0;
+    font-size: 0.85rem;
+    color: var(--color-muted);
+}
+
+@media (max-width: 960px) {
+    .nav-links {
+        position: absolute;
+        top: 120%;
+        right: 0;
+        background: rgba(255, 255, 255, 0.97);
+        flex-direction: column;
+        align-items: flex-start;
+        padding: 1.5rem;
+        border-radius: 18px;
+        box-shadow: var(--shadow-soft);
+        min-width: 220px;
+        transform: scale(0.9);
+        opacity: 0;
+        pointer-events: none;
+        transition: opacity 0.2s ease, transform 0.2s ease;
+    }
+
+    .nav-links.is-open {
+        opacity: 1;
+        pointer-events: auto;
+        transform: scale(1);
+    }
+
+    .nav-toggle[aria-expanded="true"] .nav-toggle-bar {
+        background: transparent;
+    }
+
+    .nav-toggle[aria-expanded="true"] .nav-toggle-bar::before {
+        transform: rotate(45deg);
+    }
+
+    .nav-toggle[aria-expanded="true"] .nav-toggle-bar::after {
+        transform: rotate(-45deg);
+    }
+
+    .site-footer {
+        margin-top: 4rem;
+    }
+}
+
+@media (min-width: 961px) {
+    .nav-toggle {
+        display: none;
+    }
+
+    .hero-content {
+        grid-template-columns: repeat(2, minmax(0, 1fr));
+    }
+}
+
+@media (prefers-reduced-motion: reduce) {
+    *,
+    *::before,
+    *::after {
+        transition: none !important;
+        animation-duration: 0.01ms !important;
+        animation-iteration-count: 1 !important;
+    }
+}

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -1,0 +1,87 @@
+(function () {
+    const docEl = document.documentElement;
+    docEl.classList.remove('no-js');
+    document.body.classList.remove('no-js');
+
+    const navToggle = document.querySelector('.nav-toggle');
+    const navLinks = document.querySelector('.nav-links');
+
+    if (navToggle && navLinks) {
+        navToggle.addEventListener('click', () => {
+            const expanded = navToggle.getAttribute('aria-expanded') === 'true';
+            navToggle.setAttribute('aria-expanded', String(!expanded));
+            navLinks.classList.toggle('is-open');
+        });
+
+        navLinks.addEventListener('click', (event) => {
+            if (event.target instanceof HTMLElement && event.target.matches('a')) {
+                navToggle.setAttribute('aria-expanded', 'false');
+                navLinks.classList.remove('is-open');
+            }
+        });
+    }
+
+    const observer = new IntersectionObserver(
+        (entries) => {
+            entries.forEach((entry) => {
+                if (entry.isIntersecting) {
+                    entry.target.classList.add('in-view');
+                    observer.unobserve(entry.target);
+                }
+            });
+        },
+        { threshold: 0.2 }
+    );
+
+    document
+        .querySelectorAll('.service-card, .portfolio-card, .portfolio-item, .pricing-card, .stat-card')
+        .forEach((el) => {
+            el.classList.add('reveal');
+            observer.observe(el);
+        });
+
+    const filterButtons = document.querySelectorAll('.filter-button');
+    const portfolioItems = document.querySelectorAll('.portfolio-item');
+
+    filterButtons.forEach((button) => {
+        button.addEventListener('click', () => {
+            const filter = button.getAttribute('data-filter');
+            filterButtons.forEach((btn) => btn.classList.remove('is-active'));
+            button.classList.add('is-active');
+
+            portfolioItems.forEach((item) => {
+                const category = item.getAttribute('data-category');
+                const isVisible = filter === 'all' || category === filter;
+                item.setAttribute('aria-hidden', String(!isVisible));
+                item.style.display = isVisible ? 'flex' : 'none';
+            });
+        });
+    });
+
+    document.querySelectorAll('[data-scroll="contact"]').forEach((button) => {
+        button.addEventListener('click', (event) => {
+            const contactSection = document.getElementById('contact');
+            if (contactSection) {
+                event.preventDefault();
+                contactSection.scrollIntoView({ behavior: 'smooth' });
+            }
+        });
+    });
+
+    const recaptchaSiteKey = window.RECAPTCHA_SITE_KEY;
+    if (typeof grecaptcha !== 'undefined' && recaptchaSiteKey) {
+        grecaptcha.ready(() => {
+            grecaptcha
+                .execute(recaptchaSiteKey, { action: 'contact' })
+                .then((token) => {
+                    const tokenField = document.getElementById('recaptcha-token');
+                    if (tokenField) {
+                        tokenField.value = token;
+                    }
+                })
+                .catch(() => {
+                    console.warn('Nu s-a putut genera tokenul reCAPTCHA.');
+                });
+        });
+    }
+})();

--- a/config/secretkey.php
+++ b/config/secretkey.php
@@ -1,0 +1,2 @@
+<?php
+define('RECAPTCHA_SECRET_KEY', 'YOUR_SECRET_KEY_HERE');

--- a/config/sitekey.php
+++ b/config/sitekey.php
@@ -1,0 +1,2 @@
+<?php
+define('RECAPTCHA_SITE_KEY', 'YOUR_SITE_KEY_HERE');

--- a/contact.php
+++ b/contact.php
@@ -1,0 +1,75 @@
+<?php
+require_once __DIR__ . '/includes/security-headers.php';
+$pageTitle = 'Contact - Agenție Web Design | DesignToro';
+$pageDescription = 'Contactează echipa DesignToro pentru o ofertă personalizată de web design, SEO sau marketing digital.';
+$pageKeywords = 'contact web design, ofertă personalizată site, agenție bucurești contact';
+$pageUrl = 'https://www.designtoro.ro/contact';
+$formResponse = null;
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    require_once __DIR__ . '/includes/contact-handler.php';
+    $formResponse = handle_contact_form();
+}
+include __DIR__ . '/partials/head.php';
+?>
+<section class="contact-hero" aria-labelledby="contact-title">
+    <div class="container contact-grid">
+        <div>
+            <h1 id="contact-title">Hai să stăm de vorbă.</h1>
+            <p>Spune-ne câteva detalii despre proiectul tău și îți vom răspunde în cel mult o zi lucrătoare.</p>
+            <ul class="contact-details">
+                <li><strong>Telefon:</strong> <a href="tel:+40722123456">+40 722 123 456</a></li>
+                <li><strong>Email:</strong> <a href="mailto:contact@designtoro.ro">contact@designtoro.ro</a></li>
+                <li><strong>Adresă:</strong> București, România</li>
+            </ul>
+        </div>
+        <div>
+            <form class="contact-form" method="post" action="/contact.php" novalidate>
+                <?php if ($formResponse): ?>
+                    <div class="form-feedback <?= $formResponse['success'] ? 'success' : 'error'; ?>">
+                        <?php if ($formResponse['success']): ?>
+                            <p>Îți mulțumim! Mesajul a fost trimis cu succes.</p>
+                        <?php else: ?>
+                            <ul>
+                                <?php foreach ($formResponse['errors'] as $error): ?>
+                                    <li><?= $error; ?></li>
+                                <?php endforeach; ?>
+                            </ul>
+                        <?php endif; ?>
+                    </div>
+                <?php endif; ?>
+                <div class="form-group">
+                    <label for="name">Nume *</label>
+                    <input type="text" id="name" name="name" required>
+                </div>
+                <div class="form-group">
+                    <label for="email">Email *</label>
+                    <input type="email" id="email" name="email" required>
+                </div>
+                <div class="form-group">
+                    <label for="phone">Telefon</label>
+                    <input type="tel" id="phone" name="phone">
+                </div>
+                <div class="form-group honeypot">
+                    <label for="company">Companie</label>
+                    <input type="text" id="company" name="company" autocomplete="off">
+                </div>
+                <div class="form-group">
+                    <label for="message">Mesaj *</label>
+                    <textarea id="message" name="message" rows="5" required></textarea>
+                </div>
+                <input type="hidden" name="g-recaptcha-response" id="recaptcha-token">
+                <button class="btn btn-accent" type="submit">Trimite mesajul</button>
+            </form>
+        </div>
+    </div>
+</section>
+<section class="cta-banner" aria-labelledby="cta-contact">
+    <div class="container cta-inline">
+        <div>
+            <h2 id="cta-contact">Preferi o întâlnire față în față?</h2>
+            <p>Stabilește o sesiune de consultanță și vom analiza împreună soluțiile potrivite.</p>
+        </div>
+        <a class="btn btn-secondary" href="tel:+40722123456">Sună acum</a>
+    </div>
+</section>
+<?php include __DIR__ . '/partials/footer.php'; ?>

--- a/includes/contact-handler.php
+++ b/includes/contact-handler.php
@@ -1,0 +1,87 @@
+<?php
+require_once __DIR__ . '/../config/secretkey.php';
+
+function sanitize_input(string $value): string
+{
+    $value = trim($value);
+    $value = strip_tags($value);
+    return htmlspecialchars($value, ENT_QUOTES, 'UTF-8');
+}
+
+function verify_recaptcha(string $token, string $remoteIp): bool
+{
+    if (RECAPTCHA_SECRET_KEY === 'YOUR_SECRET_KEY_HERE') {
+        return false;
+    }
+
+    $response = file_get_contents(
+        'https://www.google.com/recaptcha/api/siteverify?secret='
+        . urlencode(RECAPTCHA_SECRET_KEY)
+        . '&response=' . urlencode($token)
+        . '&remoteip=' . urlencode($remoteIp)
+    );
+
+    if (!$response) {
+        return false;
+    }
+
+    $result = json_decode($response, true);
+    return is_array($result) && ($result['success'] ?? false) === true && ($result['score'] ?? 0) >= 0.5;
+}
+
+function handle_contact_form(): array
+{
+    $errors = [];
+    $honeypot = $_POST['company'] ?? '';
+    if (!empty($honeypot)) {
+        $errors[] = 'Formular invalid.';
+        return ['success' => false, 'errors' => $errors];
+    }
+
+    $name = sanitize_input($_POST['name'] ?? '');
+    $email = filter_var($_POST['email'] ?? '', FILTER_SANITIZE_EMAIL);
+    $phone = sanitize_input($_POST['phone'] ?? '');
+    $message = sanitize_input($_POST['message'] ?? '');
+    $token = $_POST['g-recaptcha-response'] ?? '';
+
+    if ($name === '') {
+        $errors[] = 'Numele este obligatoriu.';
+    }
+
+    if ($email === '' || !filter_var($email, FILTER_VALIDATE_EMAIL)) {
+        $errors[] = 'Adresa de email nu este validă.';
+    }
+
+    if ($message === '') {
+        $errors[] = 'Mesajul este obligatoriu.';
+    }
+
+    if ($token === '') {
+        $errors[] = 'Verificarea reCAPTCHA a eșuat.';
+    } elseif (!verify_recaptcha($token, $_SERVER['REMOTE_ADDR'] ?? '')) {
+        $errors[] = 'Nu am putut valida reCAPTCHA.';
+    }
+
+    if (!empty($errors)) {
+        return ['success' => false, 'errors' => $errors];
+    }
+
+    $subject = 'Mesaj nou de pe DesignToro.ro';
+    $body = "Nume: {$name}\nEmail: {$email}\nTelefon: {$phone}\nMesaj:\n{$message}";
+    $headers = 'From: no-reply@designtoro.ro' . "\r\n" . 'Reply-To: ' . $email;
+
+    $mailSent = false;
+    if (function_exists('mail')) {
+        $mailSent = mail('contact@designtoro.ro', $subject, $body, $headers);
+    }
+
+    if (!$mailSent) {
+        return [
+            'success' => false,
+            'errors' => ['Momentan nu putem trimite mesajul. Vă rugăm să ne contactați telefonic.']
+        ];
+    }
+
+    return ['success' => true, 'errors' => []];
+}
+?>

--- a/includes/security-headers.php
+++ b/includes/security-headers.php
@@ -1,0 +1,22 @@
+<?php
+if (!headers_sent()) {
+    header('Strict-Transport-Security: max-age=31536000; includeSubDomains; preload');
+    header('X-Frame-Options: DENY');
+    header('X-Content-Type-Options: nosniff');
+    header('Referrer-Policy: no-referrer-when-downgrade');
+    header('Permissions-Policy: camera=(), microphone=(), geolocation=()');
+    header(
+        'Content-Security-Policy: '
+        . "default-src 'self'; "
+        . "img-src 'self' data: https://www.gstatic.com https://www.google.com; "
+        . "script-src 'self' https://www.google.com/recaptcha/ https://www.gstatic.com/recaptcha/; "
+        . "style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; "
+        . "font-src 'self' https://fonts.gstatic.com; "
+        . "connect-src 'self'; "
+        . "frame-src https://www.google.com/recaptcha/; "
+        . "base-uri 'self'; "
+        . "form-action 'self'; "
+        . "upgrade-insecure-requests"
+    );
+}
+?>

--- a/index.php
+++ b/index.php
@@ -1,0 +1,143 @@
+<?php
+require_once __DIR__ . '/includes/security-headers.php';
+$pageTitle = 'DesignToro | Agenție Web Design & Marketing Digital București';
+$pageDescription = 'DesignToro creează experiențe digitale inspirate de Apple pentru branduri care vor să inspire acțiune.';
+$pageKeywords = 'agenție web design, creare site bucurești, marketing digital, servicii seo, promovare online';
+$pageUrl = 'https://www.designtoro.ro/';
+include __DIR__ . '/partials/head.php';
+?>
+<section class="hero" aria-labelledby="hero-title">
+    <div class="container hero-content">
+        <div class="hero-text">
+            <p class="eyebrow">Agenție Web Design & Marketing Digital</p>
+            <h1 id="hero-title">Creăm experiențe digitale care inspiră acțiune.</h1>
+            <p>DesignToro te ajută să transformi vizitatorii în clienți prin design minimalist, strategie clară și execuție impecabilă.</p>
+            <div class="hero-actions">
+                <a class="btn btn-accent" href="/portofoliu.php">Vezi portofoliul</a>
+                <a class="btn btn-ghost" href="/contact.php">Programează o discuție</a>
+            </div>
+        </div>
+        <div class="hero-media" aria-hidden="true">
+            <div class="media-placeholder">Video / Imagine de fundal</div>
+        </div>
+    </div>
+</section>
+<section class="stats" aria-label="Rezultatele DesignToro">
+    <div class="container stats-grid">
+        <div class="stat-card">
+            <span class="stat-value">225+</span>
+            <span class="stat-label">Proiecte livrate</span>
+        </div>
+        <div class="stat-card">
+            <span class="stat-value">213+</span>
+            <span class="stat-label">Clienți mulțumiți</span>
+        </div>
+        <div class="stat-card">
+            <span class="stat-value">8+</span>
+            <span class="stat-label">Ani de experiență</span>
+        </div>
+    </div>
+</section>
+<section class="services-preview" id="servicii" aria-labelledby="services-title">
+    <div class="container">
+        <h2 id="services-title">Servicii create pentru impact digital</h2>
+        <div class="service-grid">
+            <article class="service-card">
+                <div class="service-icon">Icon</div>
+                <h3>Web Design</h3>
+                <p>Site-uri de prezentare și magazine online cu design premium și experiență fluidă.</p>
+                <a class="link-arrow" href="/servicii.php#web-design">Află mai multe</a>
+            </article>
+            <article class="service-card">
+                <div class="service-icon">Icon</div>
+                <h3>SEO & Performance</h3>
+                <p>Strategii SEO tehnice și de conținut pentru poziții de top în rezultatele Google.</p>
+                <a class="link-arrow" href="/servicii.php#seo">Află mai multe</a>
+            </article>
+            <article class="service-card">
+                <div class="service-icon">Icon</div>
+                <h3>Social Media</h3>
+                <p>Campanii integrate și conținut creativ care transformă comunitățile în clienți.</p>
+                <a class="link-arrow" href="/servicii.php#social-media">Află mai multe</a>
+            </article>
+            <article class="service-card">
+                <div class="service-icon">Icon</div>
+                <h3>Branding & Content</h3>
+                <p>Identități vizuale coerente și conținut multimedia ce spun povestea brandului tău.</p>
+                <a class="link-arrow" href="/servicii.php#branding">Află mai multe</a>
+            </article>
+        </div>
+    </div>
+</section>
+<section class="portfolio-preview" aria-labelledby="portfolio-title">
+    <div class="container">
+        <div class="section-header">
+            <h2 id="portfolio-title">Portofoliu selectat</h2>
+            <a class="link-arrow" href="/portofoliu.php">Vezi toate proiectele</a>
+        </div>
+        <div class="portfolio-grid">
+            <article class="portfolio-card">
+                <div class="portfolio-media">Placeholder proiect 1</div>
+                <div class="portfolio-overlay">
+                    <h3>Proiect Vision</h3>
+                    <p>Website de prezentare</p>
+                </div>
+            </article>
+            <article class="portfolio-card">
+                <div class="portfolio-media">Placeholder proiect 2</div>
+                <div class="portfolio-overlay">
+                    <h3>Proiect Nova</h3>
+                    <p>Magazin online</p>
+                </div>
+            </article>
+            <article class="portfolio-card">
+                <div class="portfolio-media">Placeholder proiect 3</div>
+                <div class="portfolio-overlay">
+                    <h3>Proiect Aero</h3>
+                    <p>Branding & UI</p>
+                </div>
+            </article>
+            <article class="portfolio-card">
+                <div class="portfolio-media">Placeholder proiect 4</div>
+                <div class="portfolio-overlay">
+                    <h3>Proiect Atlas</h3>
+                    <p>Landing page campanie</p>
+                </div>
+            </article>
+        </div>
+    </div>
+</section>
+<section class="principles" aria-labelledby="principles-title">
+    <div class="container principles-grid">
+        <div class="principles-intro">
+            <h2 id="principles-title">Principiile noastre de colaborare</h2>
+            <p>Parteneriate transparente, procese optimizate și soluții flexibile adaptate fiecărei etape de creștere.</p>
+        </div>
+        <ul class="principles-list">
+            <li>
+                <h3>Planificare strategică</h3>
+                <p>Analizăm obiectivele și publicul pentru a crea un roadmap clar și ușor de urmărit.</p>
+            </li>
+            <li>
+                <h3>Inovație constantă</h3>
+                <p>Testăm și aplicăm cele mai noi tehnologii pentru experiențe digitale memorabile.</p>
+            </li>
+            <li>
+                <h3>Raport calitate-preț optim</h3>
+                <p>Livrăm rezultate măsurabile, cu investiții transparente și eficiente.</p>
+            </li>
+            <li>
+                <h3>Suport dedicat</h3>
+                <p>Suntem mereu alături de tine cu mentenanță, optimizări și consultanță.</p>
+            </li>
+        </ul>
+    </div>
+</section>
+<section class="cta-final" aria-labelledby="cta-title">
+    <div class="container cta-content">
+        <h2 id="cta-title">Sunteți gata să vă transformați prezența online?</h2>
+        <p>Hai să discutăm despre următorul proiect și cum îl putem duce la nivelul următor.</p>
+        <a class="btn btn-accent" href="/contact.php">Contactează-ne</a>
+    </div>
+</section>
+<?php include __DIR__ . '/partials/footer.php'; ?>

--- a/pachete.php
+++ b/pachete.php
@@ -1,0 +1,93 @@
+<?php
+require_once __DIR__ . '/includes/security-headers.php';
+$pageTitle = 'Prețuri Creare Site și Pachete Marketing | DesignToro';
+$pageDescription = 'Compară pachetele DesignToro pentru web design, marketing și mentenanță. Alege soluția potrivită afacerii tale.';
+$pageKeywords = 'preț creare site, pachet web design, ofertă site prezentare, cost mentenanță site, prețuri marketing';
+$pageUrl = 'https://www.designtoro.ro/pachete';
+include __DIR__ . '/partials/head.php';
+?>
+<section class="page-hero" aria-labelledby="pricing-hero">
+    <div class="container narrow">
+        <h1 id="pricing-hero">Pachete adaptate nevoilor tale.</h1>
+        <p>Transparență totală, beneficii clare și flexibilitate pentru proiecte la început sau în plină expansiune.</p>
+    </div>
+</section>
+<section class="pricing" aria-label="Pachete de servicii">
+    <div class="container pricing-grid">
+        <article class="pricing-card">
+            <h2>Entry Level</h2>
+            <p class="pricing-tag">Ideal pentru start-up-uri</p>
+            <ul>
+                <li>Design landing page</li>
+                <li>Structură one-page</li>
+                <li>Copywriting de bază</li>
+                <li>Integrare formulare esențiale</li>
+            </ul>
+            <button class="btn btn-secondary" data-scroll="contact">Cere ofertă</button>
+        </article>
+        <article class="pricing-card popular">
+            <div class="badge">Cel mai popular</div>
+            <h2>Business Plus</h2>
+            <p class="pricing-tag">Potrivit pentru afaceri în creștere</p>
+            <ul>
+                <li>Design multipage personalizat</li>
+                <li>SEO on-page & analytics</li>
+                <li>Integrare blog & automatizări</li>
+                <li>Suport prioritar la lansare</li>
+            </ul>
+            <button class="btn btn-accent" data-scroll="contact">Cere ofertă</button>
+        </article>
+        <article class="pricing-card">
+            <h2>Executive</h2>
+            <p class="pricing-tag">Pentru branduri enterprise</p>
+            <ul>
+                <li>Experiențe digitale custom</li>
+                <li>Integrare CRM & marketing automation</li>
+                <li>Optimizare conversii ongoing</li>
+                <li>Consultanță dedicată CX</li>
+            </ul>
+            <button class="btn btn-secondary" data-scroll="contact">Cere ofertă</button>
+        </article>
+    </div>
+</section>
+<section class="pricing" aria-label="Pachete de mentenanță și social media">
+    <div class="container pricing-grid maintenance">
+        <article class="pricing-card">
+            <h2>Mentenanță Web</h2>
+            <ul>
+                <li>Monitorizare uptime & securitate</li>
+                <li>Actualizări lunare platformă & plugin-uri</li>
+                <li>Raportare performanță</li>
+            </ul>
+            <button class="btn btn-secondary" data-scroll="contact">Solicită pachet</button>
+        </article>
+        <article class="pricing-card">
+            <h2>Social Media Marketing</h2>
+            <ul>
+                <li>Strategie și calendar editorial</li>
+                <li>Producție creativă foto/video</li>
+                <li>Campanii plătite și raportări</li>
+            </ul>
+            <button class="btn btn-secondary" data-scroll="contact">Solicită pachet</button>
+        </article>
+    </div>
+</section>
+<section class="special-offer" aria-labelledby="offer-title">
+    <div class="container special-grid">
+        <div>
+            <h2 id="offer-title">Magazin online complet</h2>
+            <p>De la <strong>399€</strong> pentru un magazin online scalabil, optimizat pentru vânzări și automatizări.</p>
+        </div>
+        <a class="btn btn-accent" href="/contact.php">Primește ofertă personalizată</a>
+    </div>
+</section>
+<section class="cta-banner" id="contact" aria-labelledby="cta-pricing">
+    <div class="container cta-inline">
+        <div>
+            <h2 id="cta-pricing">Vrei să discutăm pachetul potrivit?</h2>
+            <p>Lasă-ne detaliile proiectului și îți răspundem cu un plan personalizat.</p>
+        </div>
+        <a class="btn btn-accent" href="/contact.php">Contactează-ne</a>
+    </div>
+</section>
+<?php include __DIR__ . '/partials/footer.php'; ?>

--- a/partials/footer.php
+++ b/partials/footer.php
@@ -1,0 +1,43 @@
+</main>
+<footer class="site-footer">
+    <div class="container footer-grid">
+        <div class="footer-column">
+            <a href="/" class="footer-logo">designtoro</a>
+            <p>Construim experiențe digitale memorabile care accelerează creșterea brandului tău.</p>
+        </div>
+        <div class="footer-column">
+            <h3>Navigare</h3>
+            <ul>
+                <li><a href="/">Acasă</a></li>
+                <li><a href="/servicii.php">Servicii</a></li>
+                <li><a href="/pachete.php">Pachete</a></li>
+                <li><a href="/portofoliu.php">Portofoliu</a></li>
+                <li><a href="/contact.php">Contact</a></li>
+            </ul>
+        </div>
+        <div class="footer-column">
+            <h3>Contact</h3>
+            <ul>
+                <li>București, România</li>
+                <li><a href="mailto:contact@designtoro.ro">contact@designtoro.ro</a></li>
+                <li><a href="tel:+40722123456">+40 722 123 456</a></li>
+            </ul>
+        </div>
+        <div class="footer-column">
+            <h3>Urmărește-ne</h3>
+            <ul class="social-links">
+                <li><a href="#" aria-label="Instagram">Instagram</a></li>
+                <li><a href="#" aria-label="LinkedIn">LinkedIn</a></li>
+                <li><a href="#" aria-label="Facebook">Facebook</a></li>
+                <li><a href="#" aria-label="YouTube">YouTube</a></li>
+            </ul>
+        </div>
+    </div>
+    <div class="footer-bottom">
+        <p>Copyright © 2025 DesignToro.ro | <a href="#">Politica de Confidențialitate</a> | <a href="#">Termeni și Condiții</a></p>
+    </div>
+</footer>
+<script src="/assets/js/main.js" defer></script>
+<script src="https://www.google.com/recaptcha/api.js?render=<?= RECAPTCHA_SITE_KEY; ?>" defer></script>
+</body>
+</html>

--- a/partials/head.php
+++ b/partials/head.php
@@ -1,0 +1,37 @@
+<?php
+if (!isset($pageTitle)) {
+    $pageTitle = 'DesignToro | Agenție Web Design & Marketing Digital București';
+}
+if (!isset($pageDescription)) {
+    $pageDescription = 'DesignToro este partenerul tău pentru creare site-uri de prezentare, magazine online și strategii de marketing digital.';
+}
+if (!isset($pageKeywords)) {
+    $pageKeywords = 'agenție web design, creare site bucurești, marketing digital, servicii seo, promovare online';
+}
+if (!isset($pageUrl)) {
+    $pageUrl = 'https://www.designtoro.ro/';
+}
+require_once __DIR__ . '/../config/sitekey.php';
+?>
+<!DOCTYPE html>
+<html lang="ro">
+<head>
+    <meta charset="UTF-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title><?= $pageTitle; ?></title>
+    <meta name="description" content="<?= $pageDescription; ?>">
+    <meta name="keywords" content="<?= $pageKeywords; ?>">
+    <link rel="canonical" href="<?= $pageUrl; ?>">
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
+    <link rel="stylesheet" href="/assets/css/style.css">
+    <script>
+        window.RECAPTCHA_SITE_KEY = '<?= RECAPTCHA_SITE_KEY; ?>';
+    </script>
+    <script>document.documentElement.classList.remove('no-js');</script>
+</head>
+<body class="no-js">
+<?php include __DIR__ . '/header.php'; ?>
+<main>

--- a/partials/header.php
+++ b/partials/header.php
@@ -1,0 +1,21 @@
+<header class="site-header" id="top">
+    <div class="container header-container">
+        <a href="/" class="logo" aria-label="DesignToro">
+            <span>designtoro</span>
+        </a>
+        <nav class="main-nav" aria-label="Navigare principală">
+            <button class="nav-toggle" aria-expanded="false" aria-controls="primary-menu">
+                <span class="sr-only">Deschide meniul</span>
+                <span class="nav-toggle-bar"></span>
+            </button>
+            <ul id="primary-menu" class="nav-links">
+                <li><a href="/" class="nav-link">Acasă</a></li>
+                <li><a href="/servicii.php" class="nav-link">Servicii</a></li>
+                <li><a href="/pachete.php" class="nav-link">Pachete</a></li>
+                <li><a href="/portofoliu.php" class="nav-link">Portofoliu</a></li>
+                <li><a href="/contact.php" class="nav-link">Contact</a></li>
+            </ul>
+        </nav>
+        <a href="/contact.php" class="btn btn-accent">Cere ofertă</a>
+    </div>
+</header>

--- a/portofoliu.php
+++ b/portofoliu.php
@@ -1,0 +1,78 @@
+<?php
+require_once __DIR__ . '/includes/security-headers.php';
+$pageTitle = 'Portofoliu Web Design și Proiecte Digitale | DesignToro';
+$pageDescription = 'Explorează proiectele DesignToro: website-uri, ecommerce și branding pentru branduri din diverse industrii.';
+$pageKeywords = 'portofoliu web design, proiecte site-uri, exemple magazine online, lucrări design';
+$pageUrl = 'https://www.designtoro.ro/portofoliu';
+include __DIR__ . '/partials/head.php';
+?>
+<section class="page-hero" aria-labelledby="portfolio-hero">
+    <div class="container narrow">
+        <h1 id="portfolio-hero">Proiecte realizate cu mândrie.</h1>
+        <p>Selecție de proiecte care îmbină designul minimalist cu performanța de top.</p>
+    </div>
+</section>
+<section class="portfolio-filters" aria-label="Filtre portofoliu">
+    <div class="container filter-buttons">
+        <button class="filter-button is-active" data-filter="all">Toate</button>
+        <button class="filter-button" data-filter="website">Website-uri</button>
+        <button class="filter-button" data-filter="ecommerce">Magazine online</button>
+        <button class="filter-button" data-filter="branding">Logo & branding</button>
+    </div>
+</section>
+<section class="portfolio-gallery" aria-label="Galerie portofoliu">
+    <div class="container portfolio-masonry">
+        <article class="portfolio-item" data-category="website">
+            <div class="portfolio-media">Placeholder Vision</div>
+            <div class="portfolio-details">
+                <h2>VisionLabs</h2>
+                <p>Website corporate</p>
+            </div>
+        </article>
+        <article class="portfolio-item" data-category="ecommerce">
+            <div class="portfolio-media">Placeholder Nova</div>
+            <div class="portfolio-details">
+                <h2>NovaStore</h2>
+                <p>Magazin online fashion</p>
+            </div>
+        </article>
+        <article class="portfolio-item" data-category="branding">
+            <div class="portfolio-media">Placeholder Aero</div>
+            <div class="portfolio-details">
+                <h2>Aero Dynamics</h2>
+                <p>Identitate vizuală</p>
+            </div>
+        </article>
+        <article class="portfolio-item" data-category="website">
+            <div class="portfolio-media">Placeholder Atlas</div>
+            <div class="portfolio-details">
+                <h2>Atlas Finance</h2>
+                <p>Landing page conversie</p>
+            </div>
+        </article>
+        <article class="portfolio-item" data-category="ecommerce">
+            <div class="portfolio-media">Placeholder Orbit</div>
+            <div class="portfolio-details">
+                <h2>Orbit Tech</h2>
+                <p>Store B2B</p>
+            </div>
+        </article>
+        <article class="portfolio-item" data-category="branding">
+            <div class="portfolio-media">Placeholder Lumen</div>
+            <div class="portfolio-details">
+                <h2>Lumen Studio</h2>
+                <p>Logo și manual de brand</p>
+            </div>
+        </article>
+    </div>
+</section>
+<section class="cta-banner" aria-labelledby="cta-portfolio">
+    <div class="container cta-inline">
+        <div>
+            <h2 id="cta-portfolio">Îți dorești un proiect la fel de memorabil?</h2>
+            <p>Scrie-ne despre provocarea ta și îți arătăm cum o putem transforma într-o poveste de succes.</p>
+        </div>
+        <a class="btn btn-accent" href="/contact.php">Hai să discutăm</a>
+    </div>
+</section>
+<?php include __DIR__ . '/partials/footer.php'; ?>

--- a/servicii.php
+++ b/servicii.php
@@ -1,0 +1,98 @@
+<?php
+require_once __DIR__ . '/includes/security-headers.php';
+$pageTitle = 'Servicii Web Design, SEO și Marketing Online | DesignToro';
+$pageDescription = 'Descoperă serviciile DesignToro: web design, optimizare SEO, social media, branding și content pentru branduri ambițioase.';
+$pageKeywords = 'servicii creare site, optimizare seo, management social media, creare magazin online, branding';
+$pageUrl = 'https://www.designtoro.ro/servicii';
+include __DIR__ . '/partials/head.php';
+?>
+<section class="page-hero" aria-labelledby="services-hero">
+    <div class="container narrow">
+        <h1 id="services-hero">Servicii complete pentru succesul tău online.</h1>
+        <p>Strategii integrate, echipă multidisciplinară și metodologie orientată spre rezultate măsurabile.</p>
+    </div>
+</section>
+<section class="service-list" aria-label="Lista serviciilor principale">
+    <div class="container service-grid detailed">
+        <article class="service-card" id="web-design">
+            <div class="service-icon">Icon</div>
+            <h2>Web Design & Dezvoltare</h2>
+            <p>Site-uri de prezentare și magazine online construite pe principii UX/UI actuale, cu performanțe ridicate și scalabilitate.</p>
+            <ul class="service-benefits">
+                <li>Audit și arhitectură de informație</li>
+                <li>Design responsiv și animații fluide</li>
+                <li>Integrare CMS și soluții ecommerce</li>
+            </ul>
+            <a class="link-arrow" href="/contact.php">Programează un discovery call</a>
+        </article>
+        <article class="service-card" id="seo">
+            <div class="service-icon">Icon</div>
+            <h2>SEO & Content Marketing</h2>
+            <p>Optimizări tehnice, content strategic și campanii off-page pentru vizibilitate organică.</p>
+            <ul class="service-benefits">
+                <li>Analiză cuvinte cheie și intentie</li>
+                <li>Optimizare tehnică și Core Web Vitals</li>
+                <li>Content marketing și link building</li>
+            </ul>
+            <a class="link-arrow" href="/contact.php">Solicită un audit SEO</a>
+        </article>
+        <article class="service-card" id="social-media">
+            <div class="service-icon">Icon</div>
+            <h2>Social Media Marketing</h2>
+            <p>Strategii multi-platformă cu conținut captivant și campanii de performanță pentru creșterea comunității.</p>
+            <ul class="service-benefits">
+                <li>Strategie editorială și tone of voice</li>
+                <li>Producție foto/video și grafică</li>
+                <li>Campanii plătite și raportare</li>
+            </ul>
+            <a class="link-arrow" href="/contact.php">Planifică o campanie</a>
+        </article>
+        <article class="service-card" id="branding">
+            <div class="service-icon">Icon</div>
+            <h2>Branding & Identitate vizuală</h2>
+            <p>Creăm identități consistente care consolidează diferențiatorii brandului pe toate canalele.</p>
+            <ul class="service-benefits">
+                <li>Naming, logo și ghid de brand</li>
+                <li>Design de materiale digitale și print</li>
+                <li>Copywriting orientat pe beneficii</li>
+            </ul>
+            <a class="link-arrow" href="/contact.php">Cere o ofertă personalizată</a>
+        </article>
+    </div>
+</section>
+<section class="service-process" aria-labelledby="process-title">
+    <div class="container process-grid">
+        <div>
+            <h2 id="process-title">Procesul nostru în 4 pași</h2>
+            <p>Un proces clar, colaborativ și agil pentru proiecte livrate la timp și fără compromisuri.</p>
+        </div>
+        <ol class="process-steps">
+            <li>
+                <h3>1. Descoperire</h3>
+                <p>Înțelegem contextul afacerii și obiectivele pentru a defini direcția strategică.</p>
+            </li>
+            <li>
+                <h3>2. Design & prototipare</h3>
+                <p>Construim wireframe-uri și prototipuri interactive pentru feedback rapid.</p>
+            </li>
+            <li>
+                <h3>3. Dezvoltare & testare</h3>
+                <p>Implementăm funcționalitățile cu standarde moderne și testare cross-device.</p>
+            </li>
+            <li>
+                <h3>4. Lansare & optimizare</h3>
+                <p>Monitorizăm performanța și optimizăm continuu pentru rezultate sustenabile.</p>
+            </li>
+        </ol>
+    </div>
+</section>
+<section class="cta-banner" aria-labelledby="cta-services">
+    <div class="container cta-inline">
+        <div>
+            <h2 id="cta-services">Hai să creăm următorul proiect emblematic.</h2>
+            <p>Completează formularul și în 24h revenim cu o propunere strategică.</p>
+        </div>
+        <a class="btn btn-accent" href="/contact.php">Cere ofertă</a>
+    </div>
+</section>
+<?php include __DIR__ . '/partials/footer.php'; ?>


### PR DESCRIPTION
## Summary
- build Apple-inspired multi-page marketing site with hero, service, portfolio, pricing and contact sections across dedicated PHP templates
- implement shared layout, responsive styling and subtle animations with a centralized Inter-based design system
- add security headers, reCAPTCHA-ready contact form handling and reusable header/footer partials for consistent UX

## Testing
- find . -name "*.php" -print0 | xargs -0 -n1 php -l

------
https://chatgpt.com/codex/tasks/task_e_68d5b6726f708327a6b3a3daf7e1139e