### PR TITLE
Refresh marketing site with Bootstrap styling and extensionless URLs

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -1,0 +1,11 @@
+RewriteEngine On
+
+# Allow access to existing files and directories
+RewriteCond %{REQUEST_FILENAME} -f [OR]
+RewriteCond %{REQUEST_FILENAME} -d
+RewriteRule ^ - [L]
+
+# Map extensionless URLs to PHP files
+RewriteCond %{REQUEST_FILENAME} !-d
+RewriteCond %{REQUEST_FILENAME}\.php -f
+RewriteRule ^(.+?)/?$ $1.php [L]

--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -2,14 +2,14 @@
     --color-bg: #ffffff;
     --color-text: #1d1d1f;
     --color-muted: #6e6e73;
-    --color-accent: #7f35ff;
-    --color-accent-strong: #ff3864;
-    --color-accent-soft: rgba(127, 53, 255, 0.12);
+    --color-accent: #1f3b73;
+    --color-accent-strong: #0f766e;
+    --color-accent-soft: rgba(31, 59, 115, 0.12);
     --color-border: rgba(29, 29, 31, 0.08);
     --color-card: rgba(255, 255, 255, 0.88);
-    --gradient-accent: linear-gradient(135deg, #ff3864 0%, #7f35ff 100%);
-    --gradient-soft: linear-gradient(135deg, rgba(255, 56, 100, 0.18) 0%, rgba(127, 53, 255, 0.12) 100%);
-    --shadow-soft: 0 20px 45px rgba(15, 15, 15, 0.08);
+    --gradient-accent: linear-gradient(135deg, #1f3b73 0%, #0f766e 100%);
+    --gradient-soft: linear-gradient(135deg, rgba(31, 59, 115, 0.18) 0%, rgba(15, 118, 110, 0.12) 100%);
+    --shadow-soft: 0 20px 45px rgba(15, 36, 55, 0.12);
     --max-width: 1200px;
 }
 
@@ -30,13 +30,13 @@ body {
     background: var(--color-bg);
 }
 
-body.no-js .nav-toggle {
-    display: none;
-}
-
 a {
     color: inherit;
     text-decoration: none;
+}
+
+.text-primary {
+    color: var(--color-accent) !important;
 }
 
 a:hover,
@@ -78,23 +78,28 @@ video {
 .btn-accent {
     background: var(--gradient-accent);
     color: #fff;
-    box-shadow: 0 12px 35px rgba(127, 53, 255, 0.28);
+    box-shadow: 0 12px 35px rgba(31, 59, 115, 0.28);
 }
 
 .btn-accent:hover,
 .btn-accent:focus {
     transform: translateY(-2px);
-    box-shadow: 0 20px 55px rgba(127, 53, 255, 0.35);
+    box-shadow: 0 20px 55px rgba(15, 118, 110, 0.35);
+    color: #fff;
+}
+
+.btn-accent:active {
+    color: #fff;
 }
 
 .btn-secondary {
-    background: rgba(127, 53, 255, 0.12);
+    background: rgba(31, 59, 115, 0.12);
     color: var(--color-accent);
 }
 
 .btn-secondary:hover,
 .btn-secondary:focus {
-    background: rgba(127, 53, 255, 0.18);
+    background: rgba(15, 118, 110, 0.18);
 }
 
 .btn-ghost {
@@ -131,106 +136,54 @@ video {
 .site-header {
     position: sticky;
     top: 0;
-    backdrop-filter: saturate(150%) blur(20px);
-    background: rgba(255, 255, 255, 0.85);
     z-index: 1000;
+    backdrop-filter: saturate(150%) blur(18px);
+}
+
+.navbar {
     border-bottom: 1px solid var(--color-border);
 }
 
-.header-container {
-    display: flex;
-    align-items: center;
-    justify-content: space-between;
-    padding: 1rem 0;
-    gap: 1.5rem;
-}
-
-.logo span,
+.navbar-brand,
 .footer-logo {
     font-weight: 700;
-    font-size: 1.25rem;
     letter-spacing: 0.08em;
     text-transform: uppercase;
 }
 
-.main-nav {
-    position: relative;
-}
-
-.nav-toggle {
-    background: none;
-    border: none;
-    width: 2.5rem;
-    height: 2.5rem;
-    border-radius: 999px;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    cursor: pointer;
-}
-
-.sr-only {
-    position: absolute;
-    width: 1px;
-    height: 1px;
-    padding: 0;
-    margin: -1px;
-    overflow: hidden;
-    clip: rect(0, 0, 0, 0);
-    white-space: nowrap;
-    border: 0;
-}
-
-.nav-toggle-bar,
-.nav-toggle-bar::before,
-.nav-toggle-bar::after {
-    content: '';
-    display: block;
-    width: 1.25rem;
-    height: 2px;
-    background: var(--color-text);
-    transition: transform 0.3s ease, opacity 0.3s ease;
-}
-
-.nav-toggle-bar::before {
-    transform: translateY(-6px);
-}
-
-.nav-toggle-bar::after {
-    transform: translateY(6px);
-}
-
-.nav-links {
-    list-style: none;
-    display: flex;
-    gap: 1.5rem;
-    margin: 0;
-    padding: 0;
-}
-
-.nav-link {
+.navbar-nav .nav-link {
     font-weight: 500;
-    padding: 0.5rem 0;
     position: relative;
+    padding: 0.5rem 0;
+    margin-inline: 0.75rem;
 }
 
-.nav-link::after {
+.navbar-nav .nav-link::after {
     content: '';
     position: absolute;
     left: 0;
     bottom: 0;
     width: 100%;
     height: 2px;
-    background: var(--color-accent);
+    background: currentColor;
     transform: scaleX(0);
     transform-origin: right;
     transition: transform 0.25s ease;
 }
 
-.nav-link:hover::after,
-.nav-link:focus::after {
+.navbar-nav .nav-link:hover::after,
+.navbar-nav .nav-link:focus::after,
+.navbar-nav .nav-link.active::after {
     transform: scaleX(1);
     transform-origin: left;
+}
+
+.navbar-toggler {
+    border-radius: 0.75rem;
+}
+
+.navbar-toggler:focus {
+    box-shadow: 0 0 0 0.25rem rgba(31, 59, 115, 0.25);
 }
 
 .hero {
@@ -238,8 +191,8 @@ video {
     padding: 6rem 0 4.5rem;
     overflow: hidden;
     background:
-        radial-gradient(140% 120% at 0% 0%, rgba(255, 56, 100, 0.18) 0%, transparent 55%),
-        radial-gradient(120% 120% at 100% 0%, rgba(127, 53, 255, 0.16) 0%, transparent 55%);
+        radial-gradient(140% 120% at 0% 0%, rgba(31, 59, 115, 0.2) 0%, transparent 55%),
+        radial-gradient(120% 120% at 100% 0%, rgba(15, 118, 110, 0.18) 0%, transparent 55%);
 }
 
 .hero::after {
@@ -247,7 +200,7 @@ video {
     position: absolute;
     inset: 10% 20% -40% 10%;
     filter: blur(120px);
-    background: linear-gradient(135deg, rgba(255, 56, 100, 0.25), rgba(127, 53, 255, 0.25));
+    background: linear-gradient(135deg, rgba(31, 59, 115, 0.25), rgba(15, 118, 110, 0.25));
     opacity: 0.6;
     z-index: 0;
 }
@@ -255,9 +208,6 @@ video {
 .hero-content {
     position: relative;
     z-index: 1;
-    display: grid;
-    gap: 3rem;
-    align-items: center;
 }
 
 .hero-text h1 {
@@ -288,14 +238,8 @@ video {
     font-weight: 500;
 }
 
-.hero-highlights li::before {
-    content: '';
-    width: 10px;
-    height: 10px;
-    border-radius: 50%;
-    background: var(--gradient-accent);
-    flex-shrink: 0;
-    margin-top: 0.45rem;
+.hero-highlights i {
+    font-size: 1.1rem;
 }
 
 .hero-badges {
@@ -323,7 +267,7 @@ video {
 .badge-pill.is-gradient {
     background: var(--gradient-accent);
     color: #fff;
-    box-shadow: 0 12px 35px rgba(127, 53, 255, 0.28);
+    box-shadow: 0 12px 35px rgba(31, 59, 115, 0.28);
 }
 
 .eyebrow {
@@ -398,7 +342,7 @@ video {
     position: absolute;
     inset: 0;
     border-radius: inherit;
-    background: linear-gradient(135deg, rgba(255, 56, 100, 0.4), rgba(127, 53, 255, 0.35));
+    background: linear-gradient(135deg, rgba(31, 59, 115, 0.45), rgba(15, 118, 110, 0.38));
     opacity: 0.65;
     z-index: -1;
 }
@@ -494,7 +438,7 @@ video {
 
 .insights {
     padding: 4.5rem 0;
-    background: linear-gradient(135deg, rgba(255, 56, 100, 0.06), rgba(127, 53, 255, 0.1));
+    background: linear-gradient(135deg, rgba(31, 59, 115, 0.08), rgba(15, 118, 110, 0.12));
 }
 
 .insights .container {
@@ -613,6 +557,12 @@ video {
     text-align: center;
 }
 
+.stat-card i {
+    display: block;
+    margin-bottom: 0.75rem;
+    color: var(--color-accent-strong);
+}
+
 .reveal {
     opacity: 0;
     transform: translateY(30px);
@@ -664,6 +614,10 @@ video {
     place-items: center;
     color: var(--color-accent);
     font-weight: 600;
+}
+
+.service-icon i {
+    font-size: 1.75rem;
 }
 
 .portfolio-preview {
@@ -755,6 +709,7 @@ video {
     flex-direction: column;
     gap: 1.5rem;
     align-items: flex-start;
+    flex-wrap: wrap;
 }
 
 .page-hero {
@@ -834,7 +789,7 @@ video {
 }
 
 .pricing-card.popular {
-    border: 1px solid rgba(127, 53, 255, 0.4);
+    border: 1px solid rgba(31, 59, 115, 0.4);
     transform: translateY(-10px);
 }
 
@@ -847,7 +802,7 @@ video {
     flex-direction: column;
     gap: 1.5rem;
     border-radius: 24px;
-    background: linear-gradient(120deg, rgba(255, 56, 100, 0.18), rgba(127, 53, 255, 0.12));
+    background: linear-gradient(120deg, rgba(31, 59, 115, 0.18), rgba(15, 118, 110, 0.12));
     padding: clamp(2.5rem, 4vw, 3.5rem);
 }
 
@@ -904,13 +859,6 @@ video {
     padding: 5rem 0;
 }
 
-.contact-grid {
-    display: grid;
-    gap: 3rem;
-    grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
-    align-items: start;
-}
-
 .contact-details {
     list-style: none;
     margin: 2rem 0 0;
@@ -918,6 +866,16 @@ video {
     display: grid;
     gap: 1rem;
     color: var(--color-muted);
+}
+
+.contact-details li {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+}
+
+.contact-details li i {
+    font-size: 1rem;
 }
 
 .contact-form {
@@ -955,7 +913,7 @@ video {
 
 .form-group input:focus,
 .form-group textarea:focus {
-    outline: 2px solid rgba(127, 53, 255, 0.2);
+    outline: 2px solid rgba(31, 59, 115, 0.2);
 }
 
 .form-feedback {
@@ -1009,6 +967,16 @@ video {
     color: var(--color-muted);
 }
 
+.footer-contact li {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+}
+
+.footer-contact li i {
+    font-size: 1.1rem;
+}
+
 .social-links a {
     display: inline-flex;
     align-items: center;
@@ -1024,53 +992,8 @@ video {
 }
 
 @media (max-width: 960px) {
-    .nav-links {
-        position: absolute;
-        top: 120%;
-        right: 0;
-        background: rgba(255, 255, 255, 0.97);
-        flex-direction: column;
-        align-items: flex-start;
-        padding: 1.5rem;
-        border-radius: 18px;
-        box-shadow: var(--shadow-soft);
-        min-width: 220px;
-        transform: scale(0.9);
-        opacity: 0;
-        pointer-events: none;
-        transition: opacity 0.2s ease, transform 0.2s ease;
-    }
-
-    .nav-links.is-open {
-        opacity: 1;
-        pointer-events: auto;
-        transform: scale(1);
-    }
-
-    .nav-toggle[aria-expanded="true"] .nav-toggle-bar {
-        background: transparent;
-    }
-
-    .nav-toggle[aria-expanded="true"] .nav-toggle-bar::before {
-        transform: rotate(45deg);
-    }
-
-    .nav-toggle[aria-expanded="true"] .nav-toggle-bar::after {
-        transform: rotate(-45deg);
-    }
-
     .site-footer {
         margin-top: 4rem;
-    }
-}
-
-@media (min-width: 961px) {
-    .nav-toggle {
-        display: none;
-    }
-
-    .hero-content {
-        grid-template-columns: repeat(2, minmax(0, 1fr));
     }
 }
 

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -3,24 +3,6 @@
     docEl.classList.remove('no-js');
     document.body.classList.remove('no-js');
 
-    const navToggle = document.querySelector('.nav-toggle');
-    const navLinks = document.querySelector('.nav-links');
-
-    if (navToggle && navLinks) {
-        navToggle.addEventListener('click', () => {
-            const expanded = navToggle.getAttribute('aria-expanded') === 'true';
-            navToggle.setAttribute('aria-expanded', String(!expanded));
-            navLinks.classList.toggle('is-open');
-        });
-
-        navLinks.addEventListener('click', (event) => {
-            if (event.target instanceof HTMLElement && event.target.matches('a')) {
-                navToggle.setAttribute('aria-expanded', 'false');
-                navLinks.classList.remove('is-open');
-            }
-        });
-    }
-
     const observer = new IntersectionObserver(
         (entries) => {
             entries.forEach((entry) => {

--- a/contact.php
+++ b/contact.php
@@ -11,19 +11,19 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
 }
 include __DIR__ . '/partials/head.php';
 ?>
-<section class="contact-hero" aria-labelledby="contact-title">
-    <div class="container contact-grid">
-        <div>
+<section class="contact-hero py-5" aria-labelledby="contact-title">
+    <div class="container contact-grid row g-5 align-items-start">
+        <div class="col-lg-5">
             <h1 id="contact-title">Hai să stăm de vorbă.</h1>
             <p>Spune-ne câteva detalii despre proiectul tău și îți vom răspunde în cel mult o zi lucrătoare.</p>
-            <ul class="contact-details">
-                <li><strong>Telefon:</strong> <a href="tel:+40722123456">+40 722 123 456</a></li>
-                <li><strong>Email:</strong> <a href="mailto:contact@designtoro.ro">contact@designtoro.ro</a></li>
-                <li><strong>Adresă:</strong> București, România</li>
+            <ul class="contact-details list-unstyled d-grid gap-2">
+                <li><i class="bi bi-telephone-fill text-primary" aria-hidden="true"></i><strong>Telefon:</strong> <a href="tel:+40722123456">+40 722 123 456</a></li>
+                <li><i class="bi bi-envelope-open-fill text-primary" aria-hidden="true"></i><strong>Email:</strong> <a href="mailto:contact@designtoro.ro">contact@designtoro.ro</a></li>
+                <li><i class="bi bi-geo-alt-fill text-primary" aria-hidden="true"></i><strong>Adresă:</strong> București, România</li>
             </ul>
         </div>
-        <div>
-            <form class="contact-form" method="post" action="/contact.php" novalidate>
+        <div class="col-lg-7">
+            <form class="contact-form" method="post" action="/contact" novalidate>
                 <?php if ($formResponse): ?>
                     <div class="form-feedback <?= $formResponse['success'] ? 'success' : 'error'; ?>">
                         <?php if ($formResponse['success']): ?>
@@ -38,24 +38,24 @@ include __DIR__ . '/partials/head.php';
                     </div>
                 <?php endif; ?>
                 <div class="form-group">
-                    <label for="name">Nume *</label>
-                    <input type="text" id="name" name="name" required>
+                    <label for="name" class="form-label">Nume *</label>
+                    <input type="text" id="name" name="name" class="form-control" required>
                 </div>
                 <div class="form-group">
-                    <label for="email">Email *</label>
-                    <input type="email" id="email" name="email" required>
+                    <label for="email" class="form-label">Email *</label>
+                    <input type="email" id="email" name="email" class="form-control" required>
                 </div>
                 <div class="form-group">
-                    <label for="phone">Telefon</label>
-                    <input type="tel" id="phone" name="phone">
+                    <label for="phone" class="form-label">Telefon</label>
+                    <input type="tel" id="phone" name="phone" class="form-control">
                 </div>
                 <div class="form-group honeypot">
                     <label for="company">Companie</label>
                     <input type="text" id="company" name="company" autocomplete="off">
                 </div>
                 <div class="form-group">
-                    <label for="message">Mesaj *</label>
-                    <textarea id="message" name="message" rows="5" required></textarea>
+                    <label for="message" class="form-label">Mesaj *</label>
+                    <textarea id="message" name="message" rows="5" class="form-control" required></textarea>
                 </div>
                 <input type="hidden" name="g-recaptcha-response" id="recaptcha-token">
                 <button class="btn btn-accent" type="submit">Trimite mesajul</button>
@@ -63,8 +63,8 @@ include __DIR__ . '/partials/head.php';
         </div>
     </div>
 </section>
-<section class="cta-banner" aria-labelledby="cta-contact">
-    <div class="container cta-inline">
+<section class="cta-banner py-5" aria-labelledby="cta-contact">
+    <div class="container cta-inline d-flex flex-column flex-lg-row align-items-lg-center justify-content-lg-between gap-3">
         <div>
             <h2 id="cta-contact">Preferi o întâlnire față în față?</h2>
             <p>Stabilește o sesiune de consultanță și vom analiza împreună soluțiile potrivite.</p>

--- a/index.php
+++ b/index.php
@@ -1,54 +1,61 @@
 <?php
 require_once __DIR__ . '/includes/security-headers.php';
 $pageTitle = 'DesignToro | Agenție Web Design & Marketing Digital București';
-$pageDescription = 'DesignToro creează experiențe digitale inspirate de Apple pentru branduri care vor să inspire acțiune.';
+$pageDescription = 'DesignToro creează experiențe digitale memorabile pentru branduri care vor să inspire acțiune.';
 $pageKeywords = 'agenție web design, creare site bucurești, marketing digital, servicii seo, promovare online';
 $pageUrl = 'https://www.designtoro.ro/';
 include __DIR__ . '/partials/head.php';
 ?>
-<section class="hero" aria-labelledby="hero-title">
-    <div class="container hero-content">
-        <div class="hero-text">
-            <p class="eyebrow">Agenție Web Design & Marketing Digital</p>
-            <div class="hero-badges">
-                <span class="badge-pill is-gradient">Agenție web design București</span>
-                <span class="badge-pill">Growth prin marketing digital</span>
+<section class="hero py-5" aria-labelledby="hero-title">
+    <div class="container">
+        <div class="row align-items-center g-5 hero-content">
+            <div class="col-lg-6 hero-text">
+                <p class="eyebrow">Agenție Web Design & Marketing Digital</p>
+                <div class="hero-badges">
+                    <span class="badge-pill is-gradient">Agenție web design București</span>
+                    <span class="badge-pill">Growth prin marketing digital</span>
+                </div>
+                <h1 id="hero-title">Creăm experiențe digitale care inspiră acțiune pentru branduri curajoase.</h1>
+                <p>DesignToro îmbină estetica clară cu tehnologie de ultimă generație pentru a construi site-uri rapide, sigure și optimizate SEO. Suntem partenerul tău de încredere când ai nevoie de branding memorabil, copy convingător și funnel-uri care convertesc.</p>
+                <ul class="hero-highlights">
+                    <li><i class="bi bi-check-circle-fill text-primary" aria-hidden="true"></i>Site-uri custom cu identitate vizuală în gradient indigo-petrol și UX centrat pe rezultate.</li>
+                    <li><i class="bi bi-rocket-takeoff-fill text-primary" aria-hidden="true"></i>Servicii SEO tehnice și de conținut pentru poziționare organică în Google pe termen lung.</li>
+                    <li><i class="bi bi-diagram-3-fill text-primary" aria-hidden="true"></i>Campanii integrate de marketing digital care aliniază social media, e-mail și reclame plătite.</li>
+                </ul>
+                <div class="hero-actions">
+                    <a class="btn btn-accent" href="/portofoliu">Vezi portofoliul</a>
+                    <a class="btn btn-ghost" href="/contact">Programează o discuție</a>
+                </div>
             </div>
-            <h1 id="hero-title">Creăm experiențe digitale care inspiră acțiune pentru branduri curajoase.</h1>
-            <p>DesignToro îmbină estetica inspirată de Apple cu tehnologie de ultimă generație pentru a construi site-uri rapide, sigure și optimizate SEO. Suntem partenerul tău de încredere când ai nevoie de branding memorabil, copy convingător și funnel-uri care convertesc.</p>
-            <ul class="hero-highlights">
-                <li>Site-uri custom cu identitate vizuală în gradient roșu-violet și UX centrat pe rezultate.</li>
-                <li>Servicii SEO tehnice și de conținut pentru poziționare organică în Google pe termen lung.</li>
-                <li>Campanii integrate de marketing digital care aliniază social media, e-mail și reclame plătite.</li>
-            </ul>
-            <div class="hero-actions">
-                <a class="btn btn-accent" href="/portofoliu.php">Vezi portofoliul</a>
-                <a class="btn btn-ghost" href="/contact.php">Programează o discuție</a>
-            </div>
-        </div>
-        <div class="hero-media" aria-hidden="true">
-            <div class="media-placeholder">
-                <h3>Experiență premium în roșu & violet.</h3>
-                <span>UI/UX minimaliste, animații fluide și performanță impecabilă.</span>
-            </div>
-            <div class="accent-card">
-                <strong>+48%</strong>
-                <span>creștere medie a ratei de conversie după relansarea site-ului</span>
+            <div class="col-lg-6">
+                <div class="hero-media" aria-hidden="true">
+                    <div class="media-placeholder">
+                        <h3>Experiență premium în indigo & petrol.</h3>
+                        <span>UI/UX minimaliste, animații fluide și performanță impecabilă.</span>
+                    </div>
+                    <div class="accent-card">
+                        <strong>+48%</strong>
+                        <span>creștere medie a ratei de conversie după relansarea site-ului</span>
+                    </div>
+                </div>
             </div>
         </div>
     </div>
 </section>
-<section class="stats" aria-label="Rezultatele DesignToro">
+<section class="stats py-5" aria-label="Rezultatele DesignToro">
     <div class="container stats-grid">
         <div class="stat-card">
+            <i class="bi bi-briefcase-fill text-primary display-6" aria-hidden="true"></i>
             <span class="stat-value">225+</span>
             <span class="stat-label">Proiecte livrate</span>
         </div>
         <div class="stat-card">
+            <i class="bi bi-emoji-smile-fill text-primary display-6" aria-hidden="true"></i>
             <span class="stat-value">213+</span>
             <span class="stat-label">Clienți mulțumiți</span>
         </div>
         <div class="stat-card">
+            <i class="bi bi-award-fill text-primary display-6" aria-hidden="true"></i>
             <span class="stat-value">8+</span>
             <span class="stat-label">Ani de experiență</span>
         </div>
@@ -74,7 +81,7 @@ include __DIR__ . '/partials/head.php';
             <h3>De ce brandurile moderne aleg DesignToro</h3>
             <p>Ne implicăm în toate etapele: cercetare, arhitectură de informație, design de interfață, dezvoltare web, SEO și marketing digital. Echipa noastră lucrează pe sprints transparente, comunică proactiv și livrează kituri complete pentru ca tu să scalezi rapid.</p>
             <ul class="about-list">
-                <li>Integrare completă a identității vizuale în gradient roșu-violet și micro-interacțiuni elegante.</li>
+                <li>Integrare completă a identității vizuale în gradient indigo-petrol și micro-interacțiuni elegante.</li>
                 <li>Audit tehnic SEO, structură de conținut și plan editorial pentru creștere sustenabilă.</li>
                 <li>Strategii de marketing digital care alimentează funnel-urile de vânzări și retenție.</li>
                 <li>Raportare clară, dashboard-uri live și suport continuu după lansare.</li>
@@ -82,33 +89,33 @@ include __DIR__ . '/partials/head.php';
         </div>
     </div>
 </section>
-<section class="services-preview" id="servicii" aria-labelledby="services-title">
+<section class="services-preview py-5" id="servicii" aria-labelledby="services-title">
     <div class="container">
         <h2 id="services-title">Servicii create pentru impact digital</h2>
         <div class="service-grid">
             <article class="service-card">
-                <div class="service-icon">Icon</div>
+                <div class="service-icon"><i class="bi bi-window-stack" aria-hidden="true"></i></div>
                 <h3>Web Design</h3>
                 <p>Site-uri de prezentare și magazine online cu design premium și experiență fluidă.</p>
-                <a class="link-arrow" href="/servicii.php#web-design">Află mai multe</a>
+                <a class="link-arrow" href="/servicii#web-design">Află mai multe</a>
             </article>
             <article class="service-card">
-                <div class="service-icon">Icon</div>
+                <div class="service-icon"><i class="bi bi-graph-up-arrow" aria-hidden="true"></i></div>
                 <h3>SEO & Performance</h3>
                 <p>Strategii SEO tehnice și de conținut pentru poziții de top în rezultatele Google.</p>
-                <a class="link-arrow" href="/servicii.php#seo">Află mai multe</a>
+                <a class="link-arrow" href="/servicii#seo">Află mai multe</a>
             </article>
             <article class="service-card">
-                <div class="service-icon">Icon</div>
+                <div class="service-icon"><i class="bi bi-people-fill" aria-hidden="true"></i></div>
                 <h3>Social Media</h3>
                 <p>Campanii integrate și conținut creativ care transformă comunitățile în clienți.</p>
-                <a class="link-arrow" href="/servicii.php#social-media">Află mai multe</a>
+                <a class="link-arrow" href="/servicii#social-media">Află mai multe</a>
             </article>
             <article class="service-card">
-                <div class="service-icon">Icon</div>
+                <div class="service-icon"><i class="bi bi-palette-fill" aria-hidden="true"></i></div>
                 <h3>Branding & Content</h3>
                 <p>Identități vizuale coerente și conținut multimedia ce spun povestea brandului tău.</p>
-                <a class="link-arrow" href="/servicii.php#branding">Află mai multe</a>
+                <a class="link-arrow" href="/servicii#branding">Află mai multe</a>
             </article>
         </div>
     </div>
@@ -117,7 +124,7 @@ include __DIR__ . '/partials/head.php';
     <div class="container">
         <div>
             <h2 id="insights-title">Strategie completă pentru creștere digitală</h2>
-            <p>Construim ecosisteme digitale care aduc trafic calificat și conversii, folosind o metodologie proprie inspirată de standardele Apple pentru simplitate și performanță. Fiecare proiect pornește cu date, apoi este rafinat cu design sistem și conținut optimizat SEO.</p>
+            <p>Construim ecosisteme digitale care aduc trafic calificat și conversii, folosind o metodologie proprie bazată pe simplitate și performanță. Fiecare proiect pornește cu date, apoi este rafinat cu design system și conținut optimizat SEO.</p>
         </div>
         <div class="insights-grid">
             <article class="insight-card">
@@ -128,7 +135,7 @@ include __DIR__ . '/partials/head.php';
             <article class="insight-card">
                 <span>Design & Dezvoltare</span>
                 <h3>Interfețe minimaliste cu performanță maximă</h3>
-                <p>Folosim sistemul nostru de design modular și tehnologii moderne pentru a crea pagini rapide, responsive și ușor de administrat. Gradientele roșu-violet dau profunzime elementelor fără a compromite lizibilitatea.</p>
+                <p>Folosim sistemul nostru de design modular și tehnologii moderne pentru a crea pagini rapide, responsive și ușor de administrat. Gradientele indigo-petrol dau profunzime elementelor fără a compromite lizibilitatea.</p>
             </article>
             <article class="insight-card">
                 <span>Optimizare continuă</span>
@@ -142,7 +149,7 @@ include __DIR__ . '/partials/head.php';
     <div class="container">
         <div class="section-header">
             <h2 id="portfolio-title">Portofoliu selectat</h2>
-            <a class="link-arrow" href="/portofoliu.php">Vezi toate proiectele</a>
+            <a class="link-arrow" href="/portofoliu">Vezi toate proiectele</a>
         </div>
         <div class="portfolio-grid">
             <article class="portfolio-card">
@@ -253,7 +260,7 @@ include __DIR__ . '/partials/head.php';
     <div class="container cta-content">
         <h2 id="cta-title">Sunteți gata să vă transformați prezența online?</h2>
         <p>Hai să discutăm despre următorul proiect și cum îl putem duce la nivelul următor.</p>
-        <a class="btn btn-accent" href="/contact.php">Contactează-ne</a>
+        <a class="btn btn-accent" href="/contact">Contactează-ne</a>
     </div>
 </section>
 <?php include __DIR__ . '/partials/footer.php'; ?>

--- a/pachete.php
+++ b/pachete.php
@@ -6,13 +6,13 @@ $pageKeywords = 'preț creare site, pachet web design, ofertă site prezentare, 
 $pageUrl = 'https://www.designtoro.ro/pachete';
 include __DIR__ . '/partials/head.php';
 ?>
-<section class="page-hero" aria-labelledby="pricing-hero">
-    <div class="container narrow">
+<section class="page-hero py-5" aria-labelledby="pricing-hero">
+    <div class="container narrow text-center">
         <h1 id="pricing-hero">Pachete adaptate nevoilor tale.</h1>
         <p>Transparență totală, beneficii clare și flexibilitate pentru proiecte la început sau în plină expansiune.</p>
     </div>
 </section>
-<section class="pricing" aria-label="Pachete de servicii">
+<section class="pricing py-5" aria-label="Pachete de servicii">
     <div class="container pricing-grid">
         <article class="pricing-card">
             <h2>Entry Level</h2>
@@ -50,7 +50,7 @@ include __DIR__ . '/partials/head.php';
         </article>
     </div>
 </section>
-<section class="pricing" aria-label="Pachete de mentenanță și social media">
+<section class="pricing py-5" aria-label="Pachete de mentenanță și social media">
     <div class="container pricing-grid maintenance">
         <article class="pricing-card">
             <h2>Mentenanță Web</h2>
@@ -78,16 +78,16 @@ include __DIR__ . '/partials/head.php';
             <h2 id="offer-title">Magazin online complet</h2>
             <p>De la <strong>399€</strong> pentru un magazin online scalabil, optimizat pentru vânzări și automatizări.</p>
         </div>
-        <a class="btn btn-accent" href="/contact.php">Primește ofertă personalizată</a>
+        <a class="btn btn-accent" href="/contact">Primește ofertă personalizată</a>
     </div>
 </section>
-<section class="cta-banner" id="contact" aria-labelledby="cta-pricing">
-    <div class="container cta-inline">
+<section class="cta-banner py-5" id="contact" aria-labelledby="cta-pricing">
+    <div class="container cta-inline d-flex flex-column flex-lg-row align-items-lg-center justify-content-lg-between gap-3">
         <div>
             <h2 id="cta-pricing">Vrei să discutăm pachetul potrivit?</h2>
             <p>Lasă-ne detaliile proiectului și îți răspundem cu un plan personalizat.</p>
         </div>
-        <a class="btn btn-accent" href="/contact.php">Contactează-ne</a>
+        <a class="btn btn-accent" href="/contact">Contactează-ne</a>
     </div>
 </section>
 <?php include __DIR__ . '/partials/footer.php'; ?>

--- a/partials/footer.php
+++ b/partials/footer.php
@@ -9,27 +9,27 @@
             <h3>Navigare</h3>
             <ul>
                 <li><a href="/">Acasă</a></li>
-                <li><a href="/servicii.php">Servicii</a></li>
-                <li><a href="/pachete.php">Pachete</a></li>
-                <li><a href="/portofoliu.php">Portofoliu</a></li>
-                <li><a href="/contact.php">Contact</a></li>
+                <li><a href="/servicii">Servicii</a></li>
+                <li><a href="/pachete">Pachete</a></li>
+                <li><a href="/portofoliu">Portofoliu</a></li>
+                <li><a href="/contact">Contact</a></li>
             </ul>
         </div>
         <div class="footer-column">
             <h3>Contact</h3>
-            <ul>
-                <li>București, România</li>
-                <li><a href="mailto:contact@designtoro.ro">contact@designtoro.ro</a></li>
-                <li><a href="tel:+40722123456">+40 722 123 456</a></li>
+            <ul class="footer-contact">
+                <li><i class="bi bi-geo-alt-fill text-primary" aria-hidden="true"></i>București, România</li>
+                <li><i class="bi bi-envelope-open-fill text-primary" aria-hidden="true"></i><a href="mailto:contact@designtoro.ro">contact@designtoro.ro</a></li>
+                <li><i class="bi bi-telephone-fill text-primary" aria-hidden="true"></i><a href="tel:+40722123456">+40 722 123 456</a></li>
             </ul>
         </div>
         <div class="footer-column">
             <h3>Urmărește-ne</h3>
             <ul class="social-links">
-                <li><a href="#" aria-label="Instagram">Instagram</a></li>
-                <li><a href="#" aria-label="LinkedIn">LinkedIn</a></li>
-                <li><a href="#" aria-label="Facebook">Facebook</a></li>
-                <li><a href="#" aria-label="YouTube">YouTube</a></li>
+                <li><a href="#" aria-label="Instagram"><i class="bi bi-instagram" aria-hidden="true"></i> Instagram</a></li>
+                <li><a href="#" aria-label="LinkedIn"><i class="bi bi-linkedin" aria-hidden="true"></i> LinkedIn</a></li>
+                <li><a href="#" aria-label="Facebook"><i class="bi bi-facebook" aria-hidden="true"></i> Facebook</a></li>
+                <li><a href="#" aria-label="YouTube"><i class="bi bi-youtube" aria-hidden="true"></i> YouTube</a></li>
             </ul>
         </div>
     </div>
@@ -37,6 +37,12 @@
         <p>Copyright © 2025 DesignToro.ro | <a href="#">Politica de Confidențialitate</a> | <a href="#">Termeni și Condiții</a></p>
     </div>
 </footer>
+<script
+    src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"
+    integrity="sha384-ENjdO4Dr2bkBIFxQpeoTz1HIcje39Wm4jDKdf19U8gI4ddQ3GYNS7NTKfAdVQSZe"
+    crossorigin="anonymous"
+    defer
+></script>
 <script src="/assets/js/main.js" defer></script>
 <script src="https://www.google.com/recaptcha/api.js?render=<?= RECAPTCHA_SITE_KEY; ?>" defer></script>
 </body>

--- a/partials/head.php
+++ b/partials/head.php
@@ -26,6 +26,18 @@ require_once __DIR__ . '/../config/sitekey.php';
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
+    <link
+        href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css"
+        rel="stylesheet"
+        integrity="sha384-QWTKZyjpPEjISv5WaRU9OFeRpok6YctnYmDr5pNlyT2bRjXh0JMhjY6hW+ALEwIH"
+        crossorigin="anonymous"
+    >
+    <link
+        rel="stylesheet"
+        href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.min.css"
+        integrity="sha384-XuZVnPY0Zru+TdBzYzNPFKVwoHEk17hMLgeNvvwSv6/XAD0KNA7CdlSJ9zhwHlVb"
+        crossorigin="anonymous"
+    >
     <link rel="stylesheet" href="/assets/css/style.css">
     <script>
         window.RECAPTCHA_SITE_KEY = '<?= RECAPTCHA_SITE_KEY; ?>';

--- a/partials/header.php
+++ b/partials/header.php
@@ -1,21 +1,28 @@
 <header class="site-header" id="top">
-    <div class="container header-container">
-        <a href="/" class="logo" aria-label="DesignToro">
-            <span>designtoro</span>
-        </a>
-        <nav class="main-nav" aria-label="Navigare principală">
-            <button class="nav-toggle" aria-expanded="false" aria-controls="primary-menu">
-                <span class="sr-only">Deschide meniul</span>
-                <span class="nav-toggle-bar"></span>
+    <nav class="navbar navbar-expand-lg navbar-light bg-white shadow-sm" aria-label="Navigare principală">
+        <div class="container">
+            <a href="/" class="navbar-brand text-uppercase fw-bold" aria-label="DesignToro">designtoro</a>
+            <button
+                class="navbar-toggler"
+                type="button"
+                data-bs-toggle="collapse"
+                data-bs-target="#primary-menu"
+                aria-controls="primary-menu"
+                aria-expanded="false"
+                aria-label="Comută meniul"
+            >
+                <span class="navbar-toggler-icon"></span>
             </button>
-            <ul id="primary-menu" class="nav-links">
-                <li><a href="/" class="nav-link">Acasă</a></li>
-                <li><a href="/servicii.php" class="nav-link">Servicii</a></li>
-                <li><a href="/pachete.php" class="nav-link">Pachete</a></li>
-                <li><a href="/portofoliu.php" class="nav-link">Portofoliu</a></li>
-                <li><a href="/contact.php" class="nav-link">Contact</a></li>
-            </ul>
-        </nav>
-        <a href="/contact.php" class="btn btn-accent">Cere ofertă</a>
-    </div>
+            <div class="collapse navbar-collapse" id="primary-menu">
+                <ul class="navbar-nav ms-auto mb-2 mb-lg-0 align-items-lg-center">
+                    <li class="nav-item"><a href="/" class="nav-link">Acasă</a></li>
+                    <li class="nav-item"><a href="/servicii" class="nav-link">Servicii</a></li>
+                    <li class="nav-item"><a href="/pachete" class="nav-link">Pachete</a></li>
+                    <li class="nav-item"><a href="/portofoliu" class="nav-link">Portofoliu</a></li>
+                    <li class="nav-item"><a href="/contact" class="nav-link">Contact</a></li>
+                </ul>
+                <a href="/contact" class="btn btn-accent ms-lg-3 mt-3 mt-lg-0">Cere ofertă</a>
+            </div>
+        </div>
+    </nav>
 </header>

--- a/portofoliu.php
+++ b/portofoliu.php
@@ -6,13 +6,13 @@ $pageKeywords = 'portofoliu web design, proiecte site-uri, exemple magazine onli
 $pageUrl = 'https://www.designtoro.ro/portofoliu';
 include __DIR__ . '/partials/head.php';
 ?>
-<section class="page-hero" aria-labelledby="portfolio-hero">
-    <div class="container narrow">
+<section class="page-hero py-5" aria-labelledby="portfolio-hero">
+    <div class="container narrow text-center">
         <h1 id="portfolio-hero">Proiecte realizate cu mândrie.</h1>
         <p>Selecție de proiecte care îmbină designul minimalist cu performanța de top.</p>
     </div>
 </section>
-<section class="portfolio-filters" aria-label="Filtre portofoliu">
+<section class="portfolio-filters py-3" aria-label="Filtre portofoliu">
     <div class="container filter-buttons">
         <button class="filter-button is-active" data-filter="all">Toate</button>
         <button class="filter-button" data-filter="website">Website-uri</button>
@@ -20,7 +20,7 @@ include __DIR__ . '/partials/head.php';
         <button class="filter-button" data-filter="branding">Logo & branding</button>
     </div>
 </section>
-<section class="portfolio-gallery" aria-label="Galerie portofoliu">
+<section class="portfolio-gallery py-4" aria-label="Galerie portofoliu">
     <div class="container portfolio-masonry">
         <article class="portfolio-item" data-category="website">
             <div class="portfolio-media">Placeholder Vision</div>
@@ -66,13 +66,13 @@ include __DIR__ . '/partials/head.php';
         </article>
     </div>
 </section>
-<section class="cta-banner" aria-labelledby="cta-portfolio">
-    <div class="container cta-inline">
+<section class="cta-banner py-5" aria-labelledby="cta-portfolio">
+    <div class="container cta-inline d-flex flex-column flex-lg-row align-items-lg-center justify-content-lg-between gap-3">
         <div>
             <h2 id="cta-portfolio">Îți dorești un proiect la fel de memorabil?</h2>
             <p>Scrie-ne despre provocarea ta și îți arătăm cum o putem transforma într-o poveste de succes.</p>
         </div>
-        <a class="btn btn-accent" href="/contact.php">Hai să discutăm</a>
+        <a class="btn btn-accent" href="/contact">Hai să discutăm</a>
     </div>
 </section>
 <?php include __DIR__ . '/partials/footer.php'; ?>

--- a/servicii.php
+++ b/servicii.php
@@ -6,16 +6,16 @@ $pageKeywords = 'servicii creare site, optimizare seo, management social media, 
 $pageUrl = 'https://www.designtoro.ro/servicii';
 include __DIR__ . '/partials/head.php';
 ?>
-<section class="page-hero" aria-labelledby="services-hero">
-    <div class="container narrow">
+<section class="page-hero py-5" aria-labelledby="services-hero">
+    <div class="container narrow text-center">
         <h1 id="services-hero">Servicii complete pentru succesul tău online.</h1>
         <p>Strategii integrate, echipă multidisciplinară și metodologie orientată spre rezultate măsurabile.</p>
     </div>
 </section>
-<section class="service-list" aria-label="Lista serviciilor principale">
+<section class="service-list py-5" aria-label="Lista serviciilor principale">
     <div class="container service-grid detailed">
         <article class="service-card" id="web-design">
-            <div class="service-icon">Icon</div>
+            <div class="service-icon"><i class="bi bi-window-desktop" aria-hidden="true"></i></div>
             <h2>Web Design & Dezvoltare</h2>
             <p>Site-uri de prezentare și magazine online construite pe principii UX/UI actuale, cu performanțe ridicate și scalabilitate.</p>
             <ul class="service-benefits">
@@ -23,10 +23,10 @@ include __DIR__ . '/partials/head.php';
                 <li>Design responsiv și animații fluide</li>
                 <li>Integrare CMS și soluții ecommerce</li>
             </ul>
-            <a class="link-arrow" href="/contact.php">Programează un discovery call</a>
+            <a class="link-arrow" href="/contact">Programează un discovery call</a>
         </article>
         <article class="service-card" id="seo">
-            <div class="service-icon">Icon</div>
+            <div class="service-icon"><i class="bi bi-search" aria-hidden="true"></i></div>
             <h2>SEO & Content Marketing</h2>
             <p>Optimizări tehnice, content strategic și campanii off-page pentru vizibilitate organică.</p>
             <ul class="service-benefits">
@@ -34,10 +34,10 @@ include __DIR__ . '/partials/head.php';
                 <li>Optimizare tehnică și Core Web Vitals</li>
                 <li>Content marketing și link building</li>
             </ul>
-            <a class="link-arrow" href="/contact.php">Solicită un audit SEO</a>
+            <a class="link-arrow" href="/contact">Solicită un audit SEO</a>
         </article>
         <article class="service-card" id="social-media">
-            <div class="service-icon">Icon</div>
+            <div class="service-icon"><i class="bi bi-chat-dots-fill" aria-hidden="true"></i></div>
             <h2>Social Media Marketing</h2>
             <p>Strategii multi-platformă cu conținut captivant și campanii de performanță pentru creșterea comunității.</p>
             <ul class="service-benefits">
@@ -45,10 +45,10 @@ include __DIR__ . '/partials/head.php';
                 <li>Producție foto/video și grafică</li>
                 <li>Campanii plătite și raportare</li>
             </ul>
-            <a class="link-arrow" href="/contact.php">Planifică o campanie</a>
+            <a class="link-arrow" href="/contact">Planifică o campanie</a>
         </article>
         <article class="service-card" id="branding">
-            <div class="service-icon">Icon</div>
+            <div class="service-icon"><i class="bi bi-palette-fill" aria-hidden="true"></i></div>
             <h2>Branding & Identitate vizuală</h2>
             <p>Creăm identități consistente care consolidează diferențiatorii brandului pe toate canalele.</p>
             <ul class="service-benefits">
@@ -56,11 +56,11 @@ include __DIR__ . '/partials/head.php';
                 <li>Design de materiale digitale și print</li>
                 <li>Copywriting orientat pe beneficii</li>
             </ul>
-            <a class="link-arrow" href="/contact.php">Cere o ofertă personalizată</a>
+            <a class="link-arrow" href="/contact">Cere o ofertă personalizată</a>
         </article>
     </div>
 </section>
-<section class="service-process" aria-labelledby="process-title">
+<section class="service-process py-5" aria-labelledby="process-title">
     <div class="container process-grid">
         <div>
             <h2 id="process-title">Procesul nostru în 4 pași</h2>
@@ -86,13 +86,13 @@ include __DIR__ . '/partials/head.php';
         </ol>
     </div>
 </section>
-<section class="cta-banner" aria-labelledby="cta-services">
-    <div class="container cta-inline">
+<section class="cta-banner py-5" aria-labelledby="cta-services">
+    <div class="container cta-inline d-flex flex-column flex-lg-row align-items-lg-center justify-content-lg-between gap-3">
         <div>
             <h2 id="cta-services">Hai să creăm următorul proiect emblematic.</h2>
             <p>Completează formularul și în 24h revenim cu o propunere strategică.</p>
         </div>
-        <a class="btn btn-accent" href="/contact.php">Cere ofertă</a>
+        <a class="btn btn-accent" href="/contact">Cere ofertă</a>
     </div>
 </section>
 <?php include __DIR__ . '/partials/footer.php'; ?>


### PR DESCRIPTION
## Summary
- integrate Bootstrap 5 and Bootstrap Icons across the layout, including a rebuilt navbar that links to extensionless routes
- restyle the homepage and marketing subpages with a new indigo–petrol gradient palette, fresh copy, and iconography while removing Apple references
- add rewrite rules and update CTAs, forms, and canonical URLs to work with extensionless endpoints

## Testing
- php -l index.php
- php -l contact.php
- php -l servicii.php
- php -l pachete.php
- php -l portofoliu.php
- php -l partials/header.php
- php -l partials/footer.php
- php -l partials/head.php

------
https://chatgpt.com/codex/tasks/task_e_68d65bbb5e788327af4d8ec5d91b76ee