### PR TITLE
Fix navigation layout in sticky header

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -153,6 +153,29 @@ video {
     padding-block: 1rem;
 }
 
+.navbar-nav {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    margin: 0;
+    padding: 0;
+    list-style: none;
+}
+
+@media (max-width: 991.98px) {
+    .navbar-nav {
+        align-items: flex-start;
+        flex-direction: column;
+        gap: 0;
+        width: 100%;
+    }
+
+    .navbar-nav .nav-link {
+        margin-inline: 0;
+        width: 100%;
+    }
+}
+
 .navbar-brand,
 .footer-logo {
     font-weight: 700;


### PR DESCRIPTION
## Summary
- force the primary navigation list to lay out horizontally with no bullets on desktop
- add responsive rules that stack the links and reset spacing on smaller screens so the collapsed menu reads cleanly

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d6635160448327a8bc8451fd79482d