### PR TITLE
Adjust header layout alignment

### DIFF
--- a/partials/header.php
+++ b/partials/header.php
@@ -1,9 +1,9 @@
 <header class="site-header" id="top">
     <nav class="navbar navbar-expand-lg navbar-dark" data-bs-theme="dark" aria-label="Navigare principală">
-        <div class="container">
-            <a href="/" class="navbar-brand text-uppercase fw-bold" aria-label="DesignToro">designtoro</a>
+        <div class="container d-flex align-items-center">
+            <a href="/" class="navbar-brand text-uppercase fw-bold me-3 me-lg-4" aria-label="DesignToro">designtoro</a>
             <button
-                class="navbar-toggler"
+                class="navbar-toggler ms-auto d-lg-none"
                 type="button"
                 data-bs-toggle="collapse"
                 data-bs-target="#primary-menu"
@@ -13,16 +13,17 @@
             >
                 <span class="navbar-toggler-icon"></span>
             </button>
-            <div class="collapse navbar-collapse" id="primary-menu">
-                <ul class="navbar-nav ms-auto mb-2 mb-lg-0 align-items-lg-center">
+            <div class="collapse navbar-collapse justify-content-lg-center order-lg-2 flex-lg-grow-1" id="primary-menu">
+                <ul class="navbar-nav mb-2 mb-lg-0 align-items-lg-center">
                     <li class="nav-item"><a href="/" class="nav-link">Acasă</a></li>
                     <li class="nav-item"><a href="/servicii" class="nav-link">Servicii</a></li>
                     <li class="nav-item"><a href="/pachete" class="nav-link">Pachete</a></li>
                     <li class="nav-item"><a href="/portofoliu" class="nav-link">Portofoliu</a></li>
                     <li class="nav-item"><a href="/contact" class="nav-link">Contact</a></li>
                 </ul>
-                <a href="/contact" class="btn btn-accent ms-lg-3 mt-3 mt-lg-0">Programează un demo</a>
+                <a href="/contact" class="btn btn-accent mt-3 d-lg-none">Programează un demo</a>
             </div>
+            <a href="/contact" class="btn btn-accent ms-3 d-none d-lg-inline-flex">Programează un demo</a>
         </div>
     </nav>
 </header>


### PR DESCRIPTION
## Summary
- realign the header so the logo stays on the left, navigation centers, and the demo CTA anchors the right side
- add dedicated desktop and mobile CTA placements to preserve responsiveness when the menu collapses

## Testing
- php -S 0.0.0.0:8000


------
https://chatgpt.com/codex/tasks/task_e_68d6646a21f483278d77a285dc702feb