### PR TITLE
Refocus site messaging on web design and marketing

### DIFF
--- a/contact.php
+++ b/contact.php
@@ -14,7 +14,7 @@ include __DIR__ . '/partials/head.php';
 <section class="contact-hero py-5" aria-labelledby="contact-title">
     <div class="container contact-grid row g-5 align-items-start">
         <div class="col-lg-5">
-            <h1 id="contact-title">Hai să planificăm premiera digitală.</h1>
+            <h1 id="contact-title">Hai să planificăm strategia digitală.</h1>
             <p>Spune-ne câteva detalii despre proiect și îți răspundem cu un plan de acțiune în maximum o zi lucrătoare.</p>
             <ul class="contact-details list-unstyled d-grid gap-2">
                 <li><i class="bi bi-telephone-fill text-primary" aria-hidden="true"></i><strong>Telefon:</strong> <a href="tel:+40722123456">+40 722 123 456</a></li>
@@ -66,8 +66,8 @@ include __DIR__ . '/partials/head.php';
 <section class="cta-banner py-5" aria-labelledby="cta-contact">
     <div class="container cta-inline d-flex flex-column flex-lg-row align-items-lg-center justify-content-lg-between gap-3">
         <div>
-            <h2 id="cta-contact">Preferi o sesiune rapidă pe video?</h2>
-            <p>Stabilește o întâlnire și discutăm live despre strategie, bugete și calendar.</p>
+            <h2 id="cta-contact">Preferi o sesiune rapidă live?</h2>
+            <p>Stabilește o întâlnire și discutăm despre strategie, bugete și calendar.</p>
         </div>
         <a class="btn btn-secondary" href="tel:+40722123456">Sună acum</a>
     </div>

--- a/index.php
+++ b/index.php
@@ -16,12 +16,12 @@ include __DIR__ . '/partials/head.php';
                     <span class="badge-pill">Design narativ &amp; funnel-uri inteligente</span>
                 </div>
                 <h1 id="hero-title">Transformăm prezența online într-o platformă care ține publicul conectat.</h1>
-                <p>DesignToro produce experiențe web imersive, inspirate de dinamica platformelor de streaming. De la art
-                direction și copywriting la arhitectură tehnică și growth marketing, tratăm fiecare proiect ca pe o producție
-                premium.</p>
+                <p>DesignToro creează experiențe web orientate spre conversie, cu fluxuri UX clare și marketing digital
+                orchestrat. De la art direction și copywriting la arhitectură tehnică și growth marketing, tratăm fiecare
+                proiect ca pe un ecosistem complet pentru creștere.</p>
                 <ul class="hero-highlights">
-                    <li><i class="bi bi-check-circle-fill text-primary" aria-hidden="true"></i>Site-uri orchestrate ca un
-                    release major, cu UI cinematic și micro-interacțiuni care amplifică emoția.</li>
+                    <li><i class="bi bi-check-circle-fill text-primary" aria-hidden="true"></i>Site-uri orchestrate pentru
+                    performanță, cu UI adaptiv și micro-interacțiuni care sporesc încrederea.</li>
                     <li><i class="bi bi-rocket-takeoff-fill text-primary" aria-hidden="true"></i>Biblioteci de conținut și
                     automatizări personalizate care transformă vizitatorii în membri loiali.</li>
                     <li><i class="bi bi-diagram-3-fill text-primary" aria-hidden="true"></i>Campanii integrate și
@@ -35,8 +35,8 @@ include __DIR__ . '/partials/head.php';
             <div class="col-lg-6">
                 <div class="hero-media" aria-hidden="true">
                     <div class="media-placeholder">
-                        <h3>Experiență completă, ready to stream.</h3>
-                        <span>Motion, storytelling și tehnologie reunite într-un singur pachet digital.</span>
+                        <h3>Experiență completă, gata de lansare.</h3>
+                        <span>UX, conținut și tehnologie reunite într-un singur pachet digital.</span>
                     </div>
                     <div class="accent-card">
                         <strong>+68%</strong>
@@ -69,10 +69,10 @@ include __DIR__ . '/partials/head.php';
 <section class="about" id="despre" aria-labelledby="about-title">
     <div class="container about-grid">
         <div class="about-summary">
-            <h2 id="about-title">Studio digital din București cu ADN cinematografic</h2>
-            <p>De peste opt ani, DesignToro planifică și lansează platforme digitale care se consumă ca un sezon complet.
-            Aliniem strategia de business cu storytelling vizual, componente modulare și tehnologie scalabilă pentru branduri ce
-            vor să captiveze publicul.</p>
+            <h2 id="about-title">Studio digital din București specializat în web design și marketing</h2>
+            <p>De peste opt ani, DesignToro planifică și lansează platforme digitale care convertesc. Aliniem strategia de
+            business cu storytelling vizual, componente modulare și tehnologie scalabilă pentru branduri ce vor să-și crească
+            vizibilitatea și vânzările.</p>
             <div class="about-metrics" role="list" aria-label="Indicatori de performanță DesignToro">
                 <div class="about-metric" role="listitem">
                     <strong>3,2x</strong>
@@ -85,14 +85,14 @@ include __DIR__ . '/partials/head.php';
             </div>
         </div>
         <div class="about-details">
-            <h3>De ce brandurile ne aleg pentru rolul principal</h3>
-            <p>Acoperim întregul pipeline: cercetare, UX, UI, content, dezvoltare, SEO și growth orchestrat. Lucrăm în sprinturi
-            transparente și livrăm kituri complete pentru echipe interne.</p>
+            <h3>De ce brandurile ne aleg pentru creștere continuă</h3>
+            <p>Acoperim întregul pipeline digital: cercetare, UX, UI, content, dezvoltare, SEO și campanii orchestrate. Lucrăm
+            în sprinturi transparente și livrăm kituri complete pentru echipe interne.</p>
             <ul class="about-list">
-                <li>Design systems modulare, contraste puternice și micro-interacțiuni inspirate din entertainment.</li>
-                <li>SEO tehnic, analytics și content calendar gândite ca un program editorial.</li>
-                <li>Automatizări CRM și campanii multi-channel care livrează reacții în timp real.</li>
-                <li>Raportare live, dashboard-uri personalizate și suport post-lansare non-stop.</li>
+                <li>Design systems modulare, contraste puternice și micro-interacțiuni orientate spre conversie.</li>
+                <li>SEO tehnic, analytics și content calendar integrate cu obiectivele de marketing.</li>
+                <li>Automatizări CRM și campanii multi-channel care livrează lead-uri calificate.</li>
+                <li>Raportare live, dashboard-uri personalizate și suport post-lansare constant.</li>
             </ul>
         </div>
     </div>
@@ -104,7 +104,7 @@ include __DIR__ . '/partials/head.php';
             <article class="service-card">
                 <div class="service-icon"><i class="bi bi-window-stack" aria-hidden="true"></i></div>
                 <h3>Experiențe Web &amp; Platforme</h3>
-                <p>Interfețe modulare, membership și ecommerce cu vibe cinematic și performanță ridicată.</p>
+                <p>Interfețe modulare, membership și ecommerce construite pentru performanță și conversii.</p>
                 <a class="link-arrow" href="/servicii#web-design">Descoperă procesul</a>
             </article>
             <article class="service-card">
@@ -122,7 +122,7 @@ include __DIR__ . '/partials/head.php';
             <article class="service-card">
                 <div class="service-icon"><i class="bi bi-palette-fill" aria-hidden="true"></i></div>
                 <h3>Branding &amp; Content Studio</h3>
-                <p>Identități vizuale, scenarii video și copywriting care vând emoție.</p>
+                <p>Identități vizuale, ghiduri de comunicare și campanii de conținut care vând.</p>
                 <a class="link-arrow" href="/servicii#branding">Vezi pachetele</a>
             </article>
         </div>
@@ -131,9 +131,9 @@ include __DIR__ . '/partials/head.php';
 <section class="insights" id="strategie-digitala" aria-labelledby="insights-title">
     <div class="container">
         <div>
-            <h2 id="insights-title">Metoda noastră de producție digitală</h2>
+            <h2 id="insights-title">Metoda noastră de creștere digitală</h2>
             <p>Construim ecosisteme digitale alimentate de date, storytelling și performanță. Fiecare proiect trece printr-un
-            pipeline clar, astfel încât lansarea să se simtă ca o premieră perfect regizată.</p>
+            pipeline clar, astfel încât lansarea să fie previzibilă și scalabilă.</p>
         </div>
         <div class="insights-grid">
             <article class="insight-card">
@@ -144,7 +144,7 @@ include __DIR__ . '/partials/head.php';
             </article>
             <article class="insight-card">
                 <span>Design &amp; Build</span>
-                <h3>UI cinematic și infrastructură gata de scalare</h3>
+                <h3>UI orientat spre conversie și infrastructură gata de scalare</h3>
                 <p>Design systems modulare, animații subtile și cod optimizat pentru încărcare rapidă pe orice device.</p>
             </article>
             <article class="insight-card">
@@ -159,7 +159,7 @@ include __DIR__ . '/partials/head.php';
 <section class="portfolio-preview" aria-labelledby="portfolio-title">
     <div class="container">
         <div class="section-header">
-            <h2 id="portfolio-title">Producții recente</h2>
+            <h2 id="portfolio-title">Proiecte recente</h2>
             <a class="link-arrow" href="/portofoliu">Vezi toată colecția</a>
         </div>
         <div class="portfolio-grid">
@@ -167,7 +167,7 @@ include __DIR__ . '/partials/head.php';
                 <div class="portfolio-media">Poster digital Pulse</div>
                 <div class="portfolio-overlay">
                     <h3>Pulse Media</h3>
-                    <p>Platformă de content serializat</p>
+                    <p>Platformă de content digital și marketing automation</p>
                 </div>
             </article>
             <article class="portfolio-card">
@@ -228,7 +228,7 @@ include __DIR__ . '/partials/head.php';
 <section class="principles" aria-labelledby="principles-title">
     <div class="container principles-grid">
         <div class="principles-intro">
-            <h2 id="principles-title">Principii de colaborare pentru proiecte blockbuster</h2>
+            <h2 id="principles-title">Principii de colaborare pentru proiecte digitale performante</h2>
             <p>Parteneriate transparente, procese rapide și soluții flexibile adaptate fiecărei etape de creștere.</p>
         </div>
         <ul class="principles-list">
@@ -275,7 +275,7 @@ include __DIR__ . '/partials/head.php';
 </section>
 <section class="cta-final" aria-labelledby="cta-title">
     <div class="container cta-content">
-        <h2 id="cta-title">Pregătit pentru premiera digitală a brandului tău?</h2>
+        <h2 id="cta-title">Pregătit pentru lansarea digitală a brandului tău?</h2>
         <p>Hai să discutăm despre următorul proiect și cum îl transformăm într-o experiență memorabilă.</p>
         <a class="btn btn-accent" href="/contact">Contactează-ne</a>
     </div>

--- a/pachete.php
+++ b/pachete.php
@@ -8,7 +8,7 @@ include __DIR__ . '/partials/head.php';
 ?>
 <section class="page-hero py-5" aria-labelledby="pricing-hero">
     <div class="container narrow text-center">
-        <h1 id="pricing-hero">Pachete create pentru lansări demne de prime-time.</h1>
+        <h1 id="pricing-hero">Pachete create pentru lansări digitale performante.</h1>
         <p>Transparență totală, beneficii clare și flexibilitate pentru branduri aflate la start sau în expansiune.</p>
     </div>
 </section>
@@ -30,7 +30,7 @@ include __DIR__ . '/partials/head.php';
             <h2>Spotlight</h2>
             <p class="pricing-tag">Pentru branduri în creștere</p>
             <ul>
-                <li>Website multipage cu UI cinematic</li>
+                <li>Website multipage cu UI orientat spre conversie</li>
                 <li>SEO on-page, content calendar și blog integrat</li>
                 <li>Automatizări lead nurturing &amp; e-mail marketing</li>
                 <li>Suport dedicat în primele 60 de zile</li>
@@ -65,7 +65,7 @@ include __DIR__ . '/partials/head.php';
             <h2>Social Media Showrunner</h2>
             <ul>
                 <li>Strategie editorială, grilă de conținut și tone of voice</li>
-                <li>Producție creativă foto/video și asset-uri animate</li>
+                <li>Producție creativă pentru social media și asset-uri animate</li>
                 <li>Campanii plătite și raportări detaliate</li>
             </ul>
             <button class="btn btn-secondary" data-scroll="contact">Solicită pachet</button>

--- a/partials/footer.php
+++ b/partials/footer.php
@@ -3,7 +3,8 @@
     <div class="container footer-grid">
         <div class="footer-column">
             <a href="/" class="footer-logo">designtoro</a>
-            <p>Proiectăm platforme digitale cu vibrație cinematică pentru branduri care vor să rămână pe ecranul publicului.</p>
+            <p>Proiectăm platforme digitale cu focus pe web design și marketing pentru branduri care vor să rămână relevante
+            online.</p>
         </div>
         <div class="footer-column">
             <h3>Explorează</h3>

--- a/portofoliu.php
+++ b/portofoliu.php
@@ -8,8 +8,8 @@ include __DIR__ . '/partials/head.php';
 ?>
 <section class="page-hero py-5" aria-labelledby="portfolio-hero">
     <div class="container narrow text-center">
-        <h1 id="portfolio-hero">Producții digitale care captivează.</h1>
-        <p>Selecție de proiecte în care designul cinematic întâlnește performanța de top.</p>
+        <h1 id="portfolio-hero">Proiecte digitale care convertesc.</h1>
+        <p>Selecție de website-uri, platforme ecommerce și campanii integrate cu rezultate măsurabile.</p>
     </div>
 </section>
 <section class="portfolio-filters py-3" aria-label="Filtre portofoliu">
@@ -26,7 +26,7 @@ include __DIR__ . '/partials/head.php';
             <div class="portfolio-media">Poster digital Pulse</div>
             <div class="portfolio-details">
                 <h2>Pulse Media</h2>
-                <p>Hub de content video &amp; podcast</p>
+                <p>Hub de content digital &amp; newsletter</p>
             </div>
         </article>
         <article class="portfolio-item" data-category="ecommerce">

--- a/servicii.php
+++ b/servicii.php
@@ -8,8 +8,8 @@ include __DIR__ . '/partials/head.php';
 ?>
 <section class="page-hero py-5" aria-labelledby="services-hero">
     <div class="container narrow text-center">
-        <h1 id="services-hero">Servicii pentru platforme digitale cu vibe cinematic.</h1>
-        <p>Strategii integrate, echipă multidisciplinară și un flux de lucru orientat spre lansări memorabile.</p>
+        <h1 id="services-hero">Servicii pentru platforme digitale orientate spre conversie.</h1>
+        <p>Strategii integrate, echipă multidisciplinară și un flux de lucru orientat spre rezultate măsurabile.</p>
     </div>
 </section>
 <section class="service-list py-5" aria-label="Lista serviciilor principale">
@@ -17,10 +17,10 @@ include __DIR__ . '/partials/head.php';
         <article class="service-card" id="web-design">
             <div class="service-icon"><i class="bi bi-window-desktop" aria-hidden="true"></i></div>
             <h2>Experiențe Web &amp; Platforme</h2>
-            <p>Site-uri de prezentare, membership și ecommerce construite ca un hub digital premium.</p>
+            <p>Site-uri de prezentare, membership și ecommerce construite ca un hub digital de performanță.</p>
             <ul class="service-benefits">
                 <li>Audit de produs și mapping al experienței utilizatorului</li>
-                <li>UI modular cu animații ready-to-stream</li>
+                <li>UI modular cu animații subtile orientate spre UX</li>
                 <li>Integrare CMS, membership și soluții ecommerce</li>
             </ul>
             <a class="link-arrow" href="/contact">Programează un discovery call</a>
@@ -42,7 +42,7 @@ include __DIR__ . '/partials/head.php';
             <p>Campanii episodice și conținut snackable care mențin comunitatea conectată.</p>
             <ul class="service-benefits">
                 <li>Tone of voice și structură editorială episodică</li>
-                <li>Producție video vertical, stories și asset-uri sociale</li>
+                <li>Producție creativă pentru stories și asset-uri sociale</li>
                 <li>Campanii paid și automatizări de retargeting</li>
             </ul>
             <a class="link-arrow" href="/contact">Planifică o campanie</a>
@@ -54,7 +54,7 @@ include __DIR__ . '/partials/head.php';
             <ul class="service-benefits">
                 <li>Platformă de brand, logo adaptiv și ghid complet</li>
                 <li>Design pentru landing page-uri, pitch deck-uri și materiale promo</li>
-                <li>Copywriting și scenarii video axate pe conversie</li>
+                <li>Copywriting și ghiduri de campanii axate pe conversie</li>
             </ul>
             <a class="link-arrow" href="/contact">Cere o ofertă personalizată</a>
         </article>


### PR DESCRIPTION
## Summary
- rewrite homepage copy to emphasize web design, conversion-focused UX, and marketing services
- align services, pricing, portfolio, and contact pages with the new positioning and remove references to video/cinematography
- update footer messaging to reflect the web design and marketing focus

## Testing
- not run (static content changes)


------
https://chatgpt.com/codex/tasks/task_e_68d66606b3388327b05db62ef310527b