### PR TITLE
Remove duplicate demo button from header

### DIFF
--- a/partials/header.php
+++ b/partials/header.php
@@ -22,7 +22,6 @@
                         <li class="nav-item"><a href="/portofoliu" class="nav-link">Portofoliu</a></li>
                         <li class="nav-item"><a href="/contact" class="nav-link">Contact</a></li>
                     </ul>
-                    <a href="/contact" class="btn btn-accent mt-3 d-lg-none w-100">Programează un demo</a>
                 </div>
                 <a href="/contact" class="btn btn-accent d-none d-lg-inline-flex navbar-cta">Programează un demo</a>
             </div>


### PR DESCRIPTION
## Summary
- remove the redundant "Programează un demo" button from the header navigation collapse so only the right-aligned button remains

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d666f301688327b1af65c175ca03be