### PR TITLE
Add Font Awesome icons and placeholder imagery

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -413,16 +413,35 @@ video {
     pointer-events: none;
 }
 
+.image-placeholder {
+    width: 100%;
+    height: auto;
+    display: block;
+    object-fit: cover;
+    background: rgba(12, 12, 18, 0.85);
+}
+
 .media-placeholder {
     position: relative;
     z-index: 1;
     display: grid;
-    gap: 0.75rem;
+    gap: 1.25rem;
     color: #fff;
     font-weight: 600;
 }
 
-.media-placeholder span {
+.media-placeholder .image-placeholder {
+    border-radius: 24px;
+    border: 1px solid rgba(255, 255, 255, 0.08);
+    box-shadow: var(--shadow-soft);
+}
+
+.media-caption {
+    display: grid;
+    gap: 0.75rem;
+}
+
+.media-caption span {
     font-size: 0.85rem;
     font-weight: 400;
     color: rgba(255, 255, 255, 0.7);
@@ -769,12 +788,20 @@ video {
 }
 
 .portfolio-media {
-    height: 100%;
-    display: grid;
-    place-items: center;
-    font-weight: 600;
-    color: rgba(255, 255, 255, 0.55);
+    position: relative;
+    aspect-ratio: 4 / 5;
     background: radial-gradient(circle at center, rgba(229, 9, 20, 0.2), transparent 70%);
+}
+
+.portfolio-media .image-placeholder {
+    position: absolute;
+    inset: 0;
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+    border-radius: 0;
+    border: 0;
+    opacity: 0.95;
 }
 
 .portfolio-overlay {
@@ -793,6 +820,20 @@ video {
 .portfolio-card:hover .portfolio-overlay,
 .portfolio-card:focus-within .portfolio-overlay {
     opacity: 1;
+}
+
+.portfolio-item .portfolio-media,
+.portfolio-card .portfolio-media {
+    width: 100%;
+}
+
+.portfolio-item .portfolio-media {
+    flex: 0 0 auto;
+}
+
+.portfolio-item .portfolio-media .image-placeholder {
+    border-radius: 0;
+    border: 0;
 }
 
 .principles {

--- a/contact.php
+++ b/contact.php
@@ -17,9 +17,9 @@ include __DIR__ . '/partials/head.php';
             <h1 id="contact-title">Hai să planificăm strategia digitală.</h1>
             <p>Spune-ne câteva detalii despre proiect și îți răspundem cu un plan de acțiune în maximum o zi lucrătoare.</p>
             <ul class="contact-details list-unstyled d-grid gap-2">
-                <li><i class="bi bi-telephone-fill text-primary" aria-hidden="true"></i><strong>Telefon:</strong> <a href="tel:+40722123456">+40 722 123 456</a></li>
-                <li><i class="bi bi-envelope-open-fill text-primary" aria-hidden="true"></i><strong>Email:</strong> <a href="mailto:contact@designtoro.ro">contact@designtoro.ro</a></li>
-                <li><i class="bi bi-geo-alt-fill text-primary" aria-hidden="true"></i><strong>Adresă:</strong> București, România</li>
+                <li><i class="fa-solid fa-phone text-primary" aria-hidden="true"></i><strong>Telefon:</strong> <a href="tel:+40722123456">+40 722 123 456</a></li>
+                <li><i class="fa-solid fa-envelope-open-text text-primary" aria-hidden="true"></i><strong>Email:</strong> <a href="mailto:contact@designtoro.ro">contact@designtoro.ro</a></li>
+                <li><i class="fa-solid fa-location-dot text-primary" aria-hidden="true"></i><strong>Adresă:</strong> București, România</li>
             </ul>
         </div>
         <div class="col-lg-7">

--- a/index.php
+++ b/index.php
@@ -20,11 +20,11 @@ include __DIR__ . '/partials/head.php';
                 orchestrat. De la art direction și copywriting la arhitectură tehnică și growth marketing, tratăm fiecare
                 proiect ca pe un ecosistem complet pentru creștere.</p>
                 <ul class="hero-highlights">
-                    <li><i class="bi bi-check-circle-fill text-primary" aria-hidden="true"></i>Site-uri orchestrate pentru
+                    <li><i class="fa-solid fa-circle-check text-primary" aria-hidden="true"></i>Site-uri orchestrate pentru
                     performanță, cu UI adaptiv și micro-interacțiuni care sporesc încrederea.</li>
-                    <li><i class="bi bi-rocket-takeoff-fill text-primary" aria-hidden="true"></i>Biblioteci de conținut și
+                    <li><i class="fa-solid fa-rocket text-primary" aria-hidden="true"></i>Biblioteci de conținut și
                     automatizări personalizate care transformă vizitatorii în membri loiali.</li>
-                    <li><i class="bi bi-diagram-3-fill text-primary" aria-hidden="true"></i>Campanii integrate și
+                    <li><i class="fa-solid fa-diagram-project text-primary" aria-hidden="true"></i>Campanii integrate și
                     optimizare continuă pentru conversii în fiecare episod al customer journey-ului.</li>
                 </ul>
                 <div class="hero-actions">
@@ -35,8 +35,11 @@ include __DIR__ . '/partials/head.php';
             <div class="col-lg-6">
                 <div class="hero-media" aria-hidden="true">
                     <div class="media-placeholder">
-                        <h3>Experiență completă, gata de lansare.</h3>
-                        <span>UX, conținut și tehnologie reunite într-un singur pachet digital.</span>
+                        <img class="image-placeholder" src="https://placehold.co/600x360/1a1a26/FFFFFF?text=DesignToro+Showcase" alt="Previzualizare proiect digital realizat de DesignToro">
+                        <div class="media-caption">
+                            <h3>Experiență completă, gata de lansare.</h3>
+                            <span>UX, conținut și tehnologie reunite într-un singur pachet digital.</span>
+                        </div>
                     </div>
                     <div class="accent-card">
                         <strong>+68%</strong>
@@ -50,17 +53,17 @@ include __DIR__ . '/partials/head.php';
 <section class="stats py-5" aria-label="Rezultatele DesignToro">
     <div class="container stats-grid">
         <div class="stat-card">
-            <i class="bi bi-briefcase-fill text-primary display-6" aria-hidden="true"></i>
+            <i class="fa-solid fa-briefcase text-primary display-6" aria-hidden="true"></i>
             <span class="stat-value">225+</span>
             <span class="stat-label">Lansări orchestrate</span>
         </div>
         <div class="stat-card">
-            <i class="bi bi-emoji-smile-fill text-primary display-6" aria-hidden="true"></i>
+            <i class="fa-solid fa-face-smile text-primary display-6" aria-hidden="true"></i>
             <span class="stat-value">213+</span>
             <span class="stat-label">Branduri în prim-plan</span>
         </div>
         <div class="stat-card">
-            <i class="bi bi-award-fill text-primary display-6" aria-hidden="true"></i>
+            <i class="fa-solid fa-award text-primary display-6" aria-hidden="true"></i>
             <span class="stat-value">8+</span>
             <span class="stat-label">Ani de producție digitală</span>
         </div>
@@ -102,25 +105,25 @@ include __DIR__ . '/partials/head.php';
         <h2 id="services-title">Servicii create pentru platforme captivante</h2>
         <div class="service-grid">
             <article class="service-card">
-                <div class="service-icon"><i class="bi bi-window-stack" aria-hidden="true"></i></div>
+                <div class="service-icon"><i class="fa-solid fa-window-restore" aria-hidden="true"></i></div>
                 <h3>Experiențe Web &amp; Platforme</h3>
                 <p>Interfețe modulare, membership și ecommerce construite pentru performanță și conversii.</p>
                 <a class="link-arrow" href="/servicii#web-design">Descoperă procesul</a>
             </article>
             <article class="service-card">
-                <div class="service-icon"><i class="bi bi-graph-up-arrow" aria-hidden="true"></i></div>
+                <div class="service-icon"><i class="fa-solid fa-chart-line" aria-hidden="true"></i></div>
                 <h3>SEO &amp; Distribuție organică</h3>
                 <p>Optimizare tehnică, conținut serializat și strategii de căutare pentru audiențe calificate.</p>
                 <a class="link-arrow" href="/servicii#seo">Solicită un audit</a>
             </article>
             <article class="service-card">
-                <div class="service-icon"><i class="bi bi-people-fill" aria-hidden="true"></i></div>
+                <div class="service-icon"><i class="fa-solid fa-users" aria-hidden="true"></i></div>
                 <h3>Social Media &amp; Communities</h3>
                 <p>Campanii episodice, conținut snackable și automatizări de engagement.</p>
                 <a class="link-arrow" href="/servicii#social-media">Planifică o campanie</a>
             </article>
             <article class="service-card">
-                <div class="service-icon"><i class="bi bi-palette-fill" aria-hidden="true"></i></div>
+                <div class="service-icon"><i class="fa-solid fa-palette" aria-hidden="true"></i></div>
                 <h3>Branding &amp; Content Studio</h3>
                 <p>Identități vizuale, ghiduri de comunicare și campanii de conținut care vând.</p>
                 <a class="link-arrow" href="/servicii#branding">Vezi pachetele</a>
@@ -164,28 +167,36 @@ include __DIR__ . '/partials/head.php';
         </div>
         <div class="portfolio-grid">
             <article class="portfolio-card">
-                <div class="portfolio-media">Poster digital Pulse</div>
+                <div class="portfolio-media">
+                    <img class="image-placeholder" src="https://placehold.co/520x360/101017/FFFFFF?text=Pulse+Media" alt="Previzualizare proiect Pulse Media">
+                </div>
                 <div class="portfolio-overlay">
                     <h3>Pulse Media</h3>
                     <p>Platformă de content digital și marketing automation</p>
                 </div>
             </article>
             <article class="portfolio-card">
-                <div class="portfolio-media">Poster digital Nebula</div>
+                <div class="portfolio-media">
+                    <img class="image-placeholder" src="https://placehold.co/520x360/181824/FFFFFF?text=Nebula+Commerce" alt="Previzualizare proiect Nebula Commerce">
+                </div>
                 <div class="portfolio-overlay">
                     <h3>Nebula Commerce</h3>
                     <p>Experiență ecommerce high-end</p>
                 </div>
             </article>
             <article class="portfolio-card">
-                <div class="portfolio-media">Poster digital Skyline</div>
+                <div class="portfolio-media">
+                    <img class="image-placeholder" src="https://placehold.co/520x360/13131c/FFFFFF?text=Skyline+Air" alt="Previzualizare proiect Skyline Air">
+                </div>
                 <div class="portfolio-overlay">
                     <h3>Skyline Air</h3>
                     <p>Portal de rezervări premium</p>
                 </div>
             </article>
             <article class="portfolio-card">
-                <div class="portfolio-media">Poster digital Prime</div>
+                <div class="portfolio-media">
+                    <img class="image-placeholder" src="https://placehold.co/520x360/171721/FFFFFF?text=Prime+Estates" alt="Previzualizare proiect Prime Estates">
+                </div>
                 <div class="portfolio-overlay">
                     <h3>Prime Estates</h3>
                     <p>Platformă imobiliară interactivă</p>

--- a/partials/footer.php
+++ b/partials/footer.php
@@ -19,18 +19,18 @@
         <div class="footer-column">
             <h3>Contact rapid</h3>
             <ul class="footer-contact">
-                <li><i class="bi bi-geo-alt-fill text-primary" aria-hidden="true"></i>București, România</li>
-                <li><i class="bi bi-envelope-open-fill text-primary" aria-hidden="true"></i><a href="mailto:contact@designtoro.ro">contact@designtoro.ro</a></li>
-                <li><i class="bi bi-telephone-fill text-primary" aria-hidden="true"></i><a href="tel:+40722123456">+40 722 123 456</a></li>
+                <li><i class="fa-solid fa-location-dot text-primary" aria-hidden="true"></i>București, România</li>
+                <li><i class="fa-solid fa-envelope-open-text text-primary" aria-hidden="true"></i><a href="mailto:contact@designtoro.ro">contact@designtoro.ro</a></li>
+                <li><i class="fa-solid fa-phone text-primary" aria-hidden="true"></i><a href="tel:+40722123456">+40 722 123 456</a></li>
             </ul>
         </div>
         <div class="footer-column">
             <h3>Urmărește lansările</h3>
             <ul class="social-links">
-                <li><a href="#" aria-label="Instagram"><i class="bi bi-instagram" aria-hidden="true"></i> Instagram</a></li>
-                <li><a href="#" aria-label="LinkedIn"><i class="bi bi-linkedin" aria-hidden="true"></i> LinkedIn</a></li>
-                <li><a href="#" aria-label="Facebook"><i class="bi bi-facebook" aria-hidden="true"></i> Facebook</a></li>
-                <li><a href="#" aria-label="YouTube"><i class="bi bi-youtube" aria-hidden="true"></i> YouTube</a></li>
+                <li><a href="#" aria-label="Instagram"><i class="fa-brands fa-instagram" aria-hidden="true"></i> Instagram</a></li>
+                <li><a href="#" aria-label="LinkedIn"><i class="fa-brands fa-linkedin" aria-hidden="true"></i> LinkedIn</a></li>
+                <li><a href="#" aria-label="Facebook"><i class="fa-brands fa-facebook" aria-hidden="true"></i> Facebook</a></li>
+                <li><a href="#" aria-label="YouTube"><i class="fa-brands fa-youtube" aria-hidden="true"></i> YouTube</a></li>
             </ul>
         </div>
     </div>

--- a/partials/head.php
+++ b/partials/head.php
@@ -34,9 +34,10 @@ require_once __DIR__ . '/../config/sitekey.php';
     >
     <link
         rel="stylesheet"
-        href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.min.css"
-        integrity="sha384-XuZVnPY0Zru+TdBzYzNPFKVwoHEk17hMLgeNvvwSv6/XAD0KNA7CdlSJ9zhwHlVb"
+        href="https://cdn.jsdelivr.net/npm/@fortawesome/fontawesome-free@6.5.2/css/all.min.css"
+        integrity="sha384-7XCRsZEFfH90GDVxLvRzIftGKa4vifnq3aeQk4gBKUEooncFGpqlzu0jJjaAiz1D"
         crossorigin="anonymous"
+        referrerpolicy="no-referrer"
     >
     <link rel="stylesheet" href="/assets/css/style.css">
     <script>

--- a/portofoliu.php
+++ b/portofoliu.php
@@ -23,42 +23,54 @@ include __DIR__ . '/partials/head.php';
 <section class="portfolio-gallery py-4" aria-label="Galerie portofoliu">
     <div class="container portfolio-masonry">
         <article class="portfolio-item" data-category="website">
-            <div class="portfolio-media">Poster digital Pulse</div>
+            <div class="portfolio-media">
+                <img class="image-placeholder" src="https://placehold.co/560x380/101017/FFFFFF?text=Pulse+Media" alt="Previzualizare proiect Pulse Media">
+            </div>
             <div class="portfolio-details">
                 <h2>Pulse Media</h2>
                 <p>Hub de content digital &amp; newsletter</p>
             </div>
         </article>
         <article class="portfolio-item" data-category="ecommerce">
-            <div class="portfolio-media">Poster digital Nebula</div>
+            <div class="portfolio-media">
+                <img class="image-placeholder" src="https://placehold.co/560x380/181824/FFFFFF?text=Nebula+Commerce" alt="Previzualizare proiect Nebula Commerce">
+            </div>
             <div class="portfolio-details">
                 <h2>Nebula Commerce</h2>
                 <p>Magazin online fashion premium</p>
             </div>
         </article>
         <article class="portfolio-item" data-category="branding">
-            <div class="portfolio-media">Poster digital Skyline</div>
+            <div class="portfolio-media">
+                <img class="image-placeholder" src="https://placehold.co/560x380/13131c/FFFFFF?text=Skyline+Air" alt="Previzualizare proiect Skyline Air">
+            </div>
             <div class="portfolio-details">
                 <h2>Skyline Air</h2>
                 <p>Identitate și platformă de rezervări</p>
             </div>
         </article>
         <article class="portfolio-item" data-category="website">
-            <div class="portfolio-media">Poster digital Prime</div>
+            <div class="portfolio-media">
+                <img class="image-placeholder" src="https://placehold.co/560x380/171721/FFFFFF?text=Prime+Estates" alt="Previzualizare proiect Prime Estates">
+            </div>
             <div class="portfolio-details">
                 <h2>Prime Estates</h2>
                 <p>Platformă imobiliară interactivă</p>
             </div>
         </article>
         <article class="portfolio-item" data-category="ecommerce">
-            <div class="portfolio-media">Poster digital Orbit</div>
+            <div class="portfolio-media">
+                <img class="image-placeholder" src="https://placehold.co/560x380/0f0f15/FFFFFF?text=Orbit+Tech" alt="Previzualizare proiect Orbit Tech">
+            </div>
             <div class="portfolio-details">
                 <h2>Orbit Tech</h2>
                 <p>Store B2B cu integrări complexe</p>
             </div>
         </article>
         <article class="portfolio-item" data-category="branding">
-            <div class="portfolio-media">Poster digital Lumen</div>
+            <div class="portfolio-media">
+                <img class="image-placeholder" src="https://placehold.co/560x380/191921/FFFFFF?text=Lumen+Studio" alt="Previzualizare proiect Lumen Studio">
+            </div>
             <div class="portfolio-details">
                 <h2>Lumen Studio</h2>
                 <p>Branding și ghid de identitate</p>

--- a/servicii.php
+++ b/servicii.php
@@ -15,7 +15,7 @@ include __DIR__ . '/partials/head.php';
 <section class="service-list py-5" aria-label="Lista serviciilor principale">
     <div class="container service-grid detailed">
         <article class="service-card" id="web-design">
-            <div class="service-icon"><i class="bi bi-window-desktop" aria-hidden="true"></i></div>
+            <div class="service-icon"><i class="fa-solid fa-display" aria-hidden="true"></i></div>
             <h2>Experiențe Web &amp; Platforme</h2>
             <p>Site-uri de prezentare, membership și ecommerce construite ca un hub digital de performanță.</p>
             <ul class="service-benefits">
@@ -26,7 +26,7 @@ include __DIR__ . '/partials/head.php';
             <a class="link-arrow" href="/contact">Programează un discovery call</a>
         </article>
         <article class="service-card" id="seo">
-            <div class="service-icon"><i class="bi bi-search" aria-hidden="true"></i></div>
+            <div class="service-icon"><i class="fa-solid fa-magnifying-glass" aria-hidden="true"></i></div>
             <h2>SEO &amp; Content Serializat</h2>
             <p>Optimizări tehnice și storytelling evergreen pentru vizibilitate organică de durată.</p>
             <ul class="service-benefits">
@@ -37,7 +37,7 @@ include __DIR__ . '/partials/head.php';
             <a class="link-arrow" href="/contact">Solicită un audit SEO</a>
         </article>
         <article class="service-card" id="social-media">
-            <div class="service-icon"><i class="bi bi-chat-dots-fill" aria-hidden="true"></i></div>
+            <div class="service-icon"><i class="fa-solid fa-comments" aria-hidden="true"></i></div>
             <h2>Social Media &amp; Communities</h2>
             <p>Campanii episodice și conținut snackable care mențin comunitatea conectată.</p>
             <ul class="service-benefits">
@@ -48,7 +48,7 @@ include __DIR__ . '/partials/head.php';
             <a class="link-arrow" href="/contact">Planifică o campanie</a>
         </article>
         <article class="service-card" id="branding">
-            <div class="service-icon"><i class="bi bi-palette-fill" aria-hidden="true"></i></div>
+            <div class="service-icon"><i class="fa-solid fa-palette" aria-hidden="true"></i></div>
             <h2>Branding &amp; Content Studio</h2>
             <p>Identități vizuale și narațiuni care construiesc conexiuni emoționale.</p>
             <ul class="service-benefits">


### PR DESCRIPTION
## Summary
- load Font Awesome globally and replace legacy Bootstrap icons across the hero, stats, services, contact, and footer sections
- inject descriptive image placeholders into the home hero, home portfolio preview, and full portfolio gallery
- refresh shared styles to support the new placeholder imagery layout and polish their presentation

## Testing
- php -l index.php
- php -l portofoliu.php
- php -l servicii.php
- php -l contact.php
- php -l partials/head.php
- php -l partials/footer.php

------
https://chatgpt.com/codex/tasks/task_e_68d6694f37e08327af50659c490908c8