### PR TITLE
Adjust mobile navigation and add sticky footer navigation

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -25,6 +25,7 @@ html {
     color: var(--color-text);
     background: var(--color-bg);
     scroll-behavior: smooth;
+    overflow-x: hidden;
 }
 
 body {
@@ -32,6 +33,7 @@ body {
     min-height: 100vh;
     background: var(--color-bg);
     color: var(--color-text);
+    overflow-x: hidden;
 }
 
 a {
@@ -164,15 +166,12 @@ video {
     margin-right: auto;
 }
 
-.navbar-layout .navbar-collapse {
-    width: 100%;
-}
-
 .navbar-cta {
     padding-inline: 1.75rem;
+    white-space: nowrap;
 }
 
-.navbar-nav {
+.navbar-links {
     display: flex;
     align-items: center;
     gap: 0.5rem;
@@ -182,44 +181,25 @@ video {
 }
 
 @media (max-width: 991.98px) {
-    .navbar-nav {
-        align-items: flex-start;
-        flex-direction: column;
-        gap: 0;
-        width: 100%;
+    .navbar-layout {
+        justify-content: space-between;
     }
 
-    .navbar-nav .nav-link {
-        margin-inline: 0;
-        width: 100%;
+    .navbar-links {
+        display: none;
     }
 
-    .navbar-layout .navbar-toggler {
+    .navbar-cta {
         margin-left: auto;
+        padding-inline: 1.35rem;
+        font-size: 0.82rem;
     }
-}
-
-.navbar-layout .navbar-collapse .btn {
-    text-align: center;
-}
-
-.navbar-layout .navbar-collapse .btn.w-100 {
-    justify-content: center;
-}
-
-.navbar-layout .navbar-nav {
-    width: 100%;
 }
 
 @media (min-width: 992px) {
-    .navbar-layout .navbar-collapse {
+    .navbar-links {
+        justify-content: center;
         flex: 1;
-        display: flex !important;
-        justify-content: center;
-    }
-
-    .navbar-layout .navbar-nav {
-        justify-content: center;
     }
 
     .navbar-cta {
@@ -240,7 +220,7 @@ video {
     color: var(--color-accent);
 }
 
-.navbar-nav .nav-link {
+.navbar-links .nav-link {
     font-weight: 500;
     position: relative;
     padding: 0.5rem 0;
@@ -251,7 +231,7 @@ video {
     font-size: 0.82rem;
 }
 
-.navbar-nav .nav-link::after {
+.navbar-links .nav-link::after {
     content: '';
     position: absolute;
     left: 0;
@@ -264,27 +244,17 @@ video {
     transition: transform 0.25s ease;
 }
 
-.navbar-nav .nav-link:hover::after,
-.navbar-nav .nav-link:focus::after,
-.navbar-nav .nav-link.active::after {
+.navbar-links .nav-link:hover::after,
+.navbar-links .nav-link:focus::after,
+.navbar-links .nav-link.active::after {
     transform: scaleX(1);
     transform-origin: left;
 }
 
-.navbar-nav .nav-link:hover,
-.navbar-nav .nav-link:focus,
-.navbar-nav .nav-link.active {
+.navbar-links .nav-link:hover,
+.navbar-links .nav-link:focus,
+.navbar-links .nav-link.active {
     color: #fff;
-}
-
-.navbar-toggler {
-    border-radius: 0.75rem;
-    border: 1px solid var(--color-border);
-    background: rgba(255, 255, 255, 0.05);
-}
-
-.navbar-toggler:focus {
-    box-shadow: 0 0 0 0.25rem rgba(229, 9, 20, 0.35);
 }
 
 .hero {
@@ -1338,6 +1308,64 @@ video {
 .site-footer a:hover,
 .site-footer a:focus {
     color: var(--color-accent);
+}
+
+.mobile-footer-nav {
+    position: fixed;
+    left: 50%;
+    bottom: calc(env(safe-area-inset-bottom, 0px) + 10px);
+    transform: translate(-50%, 0);
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 0.75rem;
+    padding: 0.75rem 1.1rem;
+    width: min(520px, calc(100% - 20px));
+    border-radius: 999px;
+    border: 1px solid rgba(255, 255, 255, 0.12);
+    background: rgba(8, 8, 14, 0.78);
+    backdrop-filter: blur(18px);
+    box-shadow: 0 28px 50px rgba(0, 0, 0, 0.45);
+    z-index: 1050;
+    transition: transform 0.3s ease, opacity 0.3s ease;
+}
+
+.mobile-footer-nav.is-hidden-zoom {
+    opacity: 0;
+    pointer-events: none;
+    transform: translate(-50%, 120%);
+}
+
+.mobile-footer-nav__link {
+    flex: 1;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 0.35rem;
+    color: #f5f5f5;
+    text-transform: uppercase;
+    letter-spacing: 0.12em;
+    font-size: 0.68rem;
+    padding: 0.35rem 0.25rem;
+    border-radius: 0.75rem;
+    transition: color 0.2s ease, background 0.2s ease;
+}
+
+.mobile-footer-nav__link i {
+    font-size: 1.05rem;
+    color: var(--color-accent);
+}
+
+.mobile-footer-nav__link:hover,
+.mobile-footer-nav__link:focus {
+    color: var(--color-accent);
+    background: rgba(229, 9, 20, 0.12);
+}
+
+@media (min-width: 992px) {
+    .mobile-footer-nav {
+        display: none;
+    }
 }
 
 .footer-column ul {

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -66,4 +66,26 @@
                 });
         });
     }
+
+    const stickyFooterNav = document.querySelector('.mobile-footer-nav');
+    if (stickyFooterNav) {
+        const updateStickyNavVisibility = () => {
+            const viewport = window.visualViewport;
+            const scale = viewport && typeof viewport.scale === 'number' ? viewport.scale : 1;
+            if (scale > 1.15) {
+                stickyFooterNav.classList.add('is-hidden-zoom');
+            } else {
+                stickyFooterNav.classList.remove('is-hidden-zoom');
+            }
+        };
+
+        updateStickyNavVisibility();
+
+        if (window.visualViewport) {
+            window.visualViewport.addEventListener('resize', updateStickyNavVisibility);
+            window.visualViewport.addEventListener('scroll', updateStickyNavVisibility);
+        } else {
+            window.addEventListener('resize', updateStickyNavVisibility);
+        }
+    }
 })();

--- a/partials/footer.php
+++ b/partials/footer.php
@@ -38,6 +38,28 @@
         <p>Copyright © 2025 DesignToro.ro | <a href="#">Politica de Confidențialitate</a> | <a href="#">Termeni și Condiții</a></p>
     </div>
 </footer>
+<nav class="mobile-footer-nav" aria-label="Navigație rapidă">
+    <a href="/" class="mobile-footer-nav__link">
+        <i class="fa-solid fa-house" aria-hidden="true"></i>
+        <span>Acasă</span>
+    </a>
+    <a href="/servicii" class="mobile-footer-nav__link">
+        <i class="fa-solid fa-layer-group" aria-hidden="true"></i>
+        <span>Servicii</span>
+    </a>
+    <a href="/pachete" class="mobile-footer-nav__link">
+        <i class="fa-solid fa-box-open" aria-hidden="true"></i>
+        <span>Pachete</span>
+    </a>
+    <a href="/portofoliu" class="mobile-footer-nav__link">
+        <i class="fa-solid fa-briefcase" aria-hidden="true"></i>
+        <span>Portofoliu</span>
+    </a>
+    <a href="/contact" class="mobile-footer-nav__link">
+        <i class="fa-solid fa-envelope" aria-hidden="true"></i>
+        <span>Contact</span>
+    </a>
+</nav>
 <script
     src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"
     integrity="sha384-ENjdO4Dr2bkBIFxQpeoTz1HIcje39Wm4jDKdf19U8gI4ddQ3GYNS7NTKfAdVQSZe"

--- a/partials/header.php
+++ b/partials/header.php
@@ -1,29 +1,16 @@
 <header class="site-header" id="top">
-    <nav class="navbar navbar-expand-lg navbar-dark" data-bs-theme="dark" aria-label="Navigare principală">
+    <nav class="navbar navbar-dark" data-bs-theme="dark" aria-label="Navigare principală">
         <div class="container">
             <div class="navbar-layout">
                 <a href="/" class="navbar-brand text-uppercase fw-bold" aria-label="DesignToro">designtoro</a>
-                <button
-                    class="navbar-toggler ms-auto d-lg-none"
-                    type="button"
-                    data-bs-toggle="collapse"
-                    data-bs-target="#primary-menu"
-                    aria-controls="primary-menu"
-                    aria-expanded="false"
-                    aria-label="Comută meniul"
-                >
-                    <span class="navbar-toggler-icon"></span>
-                </button>
-                <div class="collapse navbar-collapse" id="primary-menu">
-                    <ul class="navbar-nav mb-2 mb-lg-0 align-items-lg-center">
-                        <li class="nav-item"><a href="/" class="nav-link">Acasă</a></li>
-                        <li class="nav-item"><a href="/servicii" class="nav-link">Servicii</a></li>
-                        <li class="nav-item"><a href="/pachete" class="nav-link">Pachete</a></li>
-                        <li class="nav-item"><a href="/portofoliu" class="nav-link">Portofoliu</a></li>
-                        <li class="nav-item"><a href="/contact" class="nav-link">Contact</a></li>
-                    </ul>
-                </div>
-                <a href="/contact" class="btn btn-accent d-none d-lg-inline-flex navbar-cta">Programează un demo</a>
+                <ul class="navbar-links" id="primary-menu">
+                    <li class="nav-item"><a href="/" class="nav-link">Acasă</a></li>
+                    <li class="nav-item"><a href="/servicii" class="nav-link">Servicii</a></li>
+                    <li class="nav-item"><a href="/pachete" class="nav-link">Pachete</a></li>
+                    <li class="nav-item"><a href="/portofoliu" class="nav-link">Portofoliu</a></li>
+                    <li class="nav-item"><a href="/contact" class="nav-link">Contact</a></li>
+                </ul>
+                <a href="/contact" class="btn btn-accent navbar-cta">Programează un demo</a>
             </div>
         </div>
     </nav>


### PR DESCRIPTION
## Summary
- simplify the header so that only the brand and demo button render on mobile while desktop still shows the primary links
- add a blurred sticky footer navigation for quick access to top sections and hide it when the viewport zoom exceeds 115%
- lock horizontal overflow to prevent rightward scrolling artifacts on small screens

## Testing
- php -l partials/header.php
- php -l partials/footer.php

------
https://chatgpt.com/codex/tasks/task_e_68d66d61de2c832796e4adce9df7061d