### PR TITLE
Relax CSP for external resources and adjust hero spacing

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -359,6 +359,7 @@ video {
     flex-wrap: wrap;
     gap: 1rem;
     margin-top: 2.75rem;
+    margin-bottom: 2.5rem;
 }
 
 .hero-media {

--- a/includes/security-headers.php
+++ b/includes/security-headers.php
@@ -8,11 +8,11 @@ if (!headers_sent()) {
     header(
         'Content-Security-Policy: '
         . "default-src 'self'; "
-        . "img-src 'self' data: https://www.gstatic.com https://www.google.com; "
-        . "script-src 'self' https://www.google.com/recaptcha/ https://www.gstatic.com/recaptcha/; "
-        . "style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; "
-        . "font-src 'self' https://fonts.gstatic.com; "
-        . "connect-src 'self'; "
+        . "img-src 'self' data: https://www.gstatic.com https://www.google.com https://cdn.jsdelivr.net; "
+        . "script-src 'self' 'unsafe-inline' https://cdn.jsdelivr.net https://www.google.com https://www.gstatic.com; "
+        . "style-src 'self' 'unsafe-inline' https://fonts.googleapis.com https://cdn.jsdelivr.net; "
+        . "font-src 'self' https://fonts.gstatic.com https://cdn.jsdelivr.net data:; "
+        . "connect-src 'self' https://www.google.com https://www.gstatic.com; "
         . "frame-src https://www.google.com/recaptcha/; "
         . "base-uri 'self'; "
         . "form-action 'self'; "

--- a/index.php
+++ b/index.php
@@ -36,7 +36,6 @@ include __DIR__ . '/partials/head.php';
                 <div class="hero-media" aria-hidden="true">
                     <div class="media-placeholder">
                         <div class="media-visual hero-visual" role="img" aria-label="Previzualizare proiect digital realizat de DesignToro">
-                            <span class="media-visual__chip" aria-hidden="true">DesignToro Launch Lab</span>
                             <span class="media-visual__tag" aria-hidden="true">UX • UI • Growth</span>
                         </div>
                         <div class="media-caption">


### PR DESCRIPTION
## Summary
- extend the content security policy to permit required CDN assets and inline scripts so external styles and scripts load correctly
- remove the "DesignToro Launch Lab" chip from the hero and add breathing room below the call-to-action buttons

## Testing
- php -l includes/security-headers.php

------
https://chatgpt.com/codex/tasks/task_e_68d66eb9e8408327b5fa8477fe842b0b