### PR TITLE
Add conditional HSTS header

### DIFF
--- a/includes/security-headers.php
+++ b/includes/security-headers.php
@@ -1,6 +1,14 @@
 <?php
 if (!headers_sent()) {
-    header('Strict-Transport-Security: max-age=31536000; includeSubDomains; preload');
+    $isHttps = (
+        (!empty($_SERVER['HTTPS']) && strtolower((string) $_SERVER['HTTPS']) !== 'off')
+        || (isset($_SERVER['SERVER_PORT']) && (int) $_SERVER['SERVER_PORT'] === 443)
+        || (isset($_SERVER['HTTP_X_FORWARDED_PROTO']) && strtolower($_SERVER['HTTP_X_FORWARDED_PROTO']) === 'https')
+    );
+
+    if ($isHttps) {
+        header('Strict-Transport-Security: max-age=31536000; includeSubDomains; preload');
+    }
     header('X-Frame-Options: DENY');
     header('X-Content-Type-Options: nosniff');
     header('Referrer-Policy: no-referrer-when-downgrade');


### PR DESCRIPTION
## Summary
- ensure the Strict-Transport-Security header is only set when the request is served via HTTPS, including proxy headers

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d67726e96c8327aac55c705eed793e