### PR TITLE
Hide reCAPTCHA badge until interaction is needed

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -1426,6 +1426,19 @@ video {
     color: rgba(255, 255, 255, 0.5);
 }
 
+.grecaptcha-badge {
+    visibility: hidden;
+    opacity: 0;
+    pointer-events: none;
+    transition: opacity 0.3s ease;
+}
+
+.show-recaptcha .grecaptcha-badge {
+    visibility: visible;
+    opacity: 1;
+    pointer-events: auto;
+}
+
 @media (max-width: 960px) {
     .site-footer {
         margin-top: 4rem;

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -51,7 +51,24 @@
     });
 
     const recaptchaSiteKey = window.RECAPTCHA_SITE_KEY;
-    if (typeof grecaptcha !== 'undefined' && recaptchaSiteKey) {
+    const enableRecaptchaBadge = (auto = false) => {
+        document.body.classList.add('show-recaptcha');
+        if (auto) {
+            document.body.dataset.recaptchaAuto = 'true';
+        }
+    };
+    const disableAutoRecaptchaBadge = () => {
+        if (document.body.dataset.recaptchaAuto === 'true') {
+            document.body.classList.remove('show-recaptcha');
+            delete document.body.dataset.recaptchaAuto;
+        }
+    };
+    const initializeRecaptcha = () => {
+        if (typeof grecaptcha === 'undefined' || !recaptchaSiteKey) {
+            enableRecaptchaBadge(true);
+            return;
+        }
+
         grecaptcha.ready(() => {
             grecaptcha
                 .execute(recaptchaSiteKey, { action: 'contact' })
@@ -60,11 +77,27 @@
                     if (tokenField) {
                         tokenField.value = token;
                     }
+                    disableAutoRecaptchaBadge();
                 })
                 .catch(() => {
                     console.warn('Nu s-a putut genera tokenul reCAPTCHA.');
+                    enableRecaptchaBadge(true);
                 });
         });
+    };
+
+    if (recaptchaSiteKey) {
+        if (typeof grecaptcha !== 'undefined') {
+            initializeRecaptcha();
+        } else {
+            window.addEventListener('load', () => {
+                if (typeof grecaptcha !== 'undefined') {
+                    initializeRecaptcha();
+                } else {
+                    enableRecaptchaBadge(true);
+                }
+            });
+        }
     }
 
     const stickyFooterNav = document.querySelector('.mobile-footer-nav');

--- a/contact.php
+++ b/contact.php
@@ -10,6 +10,10 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     require_once __DIR__ . '/includes/contact-handler.php';
     $formResponse = handle_contact_form();
 }
+$bodyClasses = $bodyClasses ?? [];
+if ($formResponse && empty($formResponse['success'])) {
+    $bodyClasses[] = 'show-recaptcha';
+}
 include __DIR__ . '/partials/head.php';
 ?>
 <section class="contact-hero py-5" aria-labelledby="contact-title">

--- a/partials/head.php
+++ b/partials/head.php
@@ -12,6 +12,13 @@ if (!isset($pageUrl)) {
     $pageUrl = 'https://www.designtoro.ro/';
 }
 require_once __DIR__ . '/../config/sitekey.php';
+$bodyClasses = $bodyClasses ?? [];
+if (!is_array($bodyClasses)) {
+    $bodyClasses = [$bodyClasses];
+}
+$bodyClasses = array_filter(array_map('trim', $bodyClasses));
+array_unshift($bodyClasses, 'no-js');
+$bodyClassAttribute = htmlspecialchars(implode(' ', array_unique($bodyClasses)), ENT_QUOTES, 'UTF-8');
 ?>
 <!DOCTYPE html>
 <html lang="ro">
@@ -44,6 +51,6 @@ require_once __DIR__ . '/../config/sitekey.php';
     </script>
     <script>document.documentElement.classList.remove('no-js');</script>
 </head>
-<body class="no-js">
+<body class="<?= $bodyClassAttribute; ?>">
 <?php include __DIR__ . '/header.php'; ?>
 <main>


### PR DESCRIPTION
## Summary
- add a reusable body class helper to allow pages to opt into reCAPTCHA visibility
- hide the reCAPTCHA badge by default and expose it only when errors or manual interaction are required
- trigger the badge when the contact form fails validation or when the client cannot fetch a reCAPTCHA token

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d677affeb48327ac36a9b66294fd94