### PR TITLE
Update footer to display current year dynamically

### DIFF
--- a/partials/footer.php
+++ b/partials/footer.php
@@ -35,7 +35,7 @@
         </div>
     </div>
     <div class="footer-bottom">
-        <p>Copyright © 2025 DesignToro.ro | <a href="#">Politica de Confidențialitate</a> | <a href="#">Termeni și Condiții</a></p>
+        <p>Copyright © <?= date('Y'); ?> DesignToro.ro | <a href="#">Politica de Confidențialitate</a> | <a href="#">Termeni și Condiții</a></p>
     </div>
 </footer>
 <?php


### PR DESCRIPTION
## Summary
- replace the footer's hard-coded year with a PHP `date('Y')` call so the copyright updates automatically

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d678b60dac8327aa898d25ef2fde8e