### PR TITLE
Adjust footer spacing and shorten CTA text

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -1323,6 +1323,7 @@ video {
     background: #050505;
     color: rgba(255, 255, 255, 0.8);
     border-top: 1px solid var(--color-border);
+    padding-bottom: 4rem;
 }
 
 .footer-grid {
@@ -1452,6 +1453,8 @@ video {
 @media (max-width: 960px) {
     .site-footer {
         margin-top: 4rem;
+        padding-bottom: 6rem;
+        padding-bottom: calc(6rem + env(safe-area-inset-bottom, 0px));
     }
 }
 

--- a/partials/header.php
+++ b/partials/header.php
@@ -10,7 +10,7 @@
                     <li class="nav-item"><a href="/portofoliu" class="nav-link">Portofoliu</a></li>
                     <li class="nav-item"><a href="/contact" class="nav-link">Contact</a></li>
                 </ul>
-                <a href="/contact" class="btn btn-accent navbar-cta">Programează un demo</a>
+                <a href="/contact" class="btn btn-accent navbar-cta">Solicită demo</a>
             </div>
         </div>
     </nav>


### PR DESCRIPTION
## Summary
- add extra padding to the footer so mobile navigation no longer overlays the bottom links
- shorten the header CTA label to keep it within the viewport

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d67a9a71548327a74be0dfa1fecb48