### PR TITLE
Replace hero metric card with three accent highlights

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -325,26 +325,20 @@ video {
 
 .hero-metric {
     margin-top: 3rem;
-    display: flex;
-    justify-content: flex-start;
+    display: grid;
+    gap: 1.5rem;
+    grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
 }
 
 .hero-metric .accent-card {
-    max-width: 420px;
     display: grid;
-    gap: 0.6rem;
+    gap: 0.35rem;
+    align-content: flex-start;
 }
 
-.hero-metric .accent-card h3 {
-    margin: 0;
-    font-size: 1.3rem;
-    color: #fff;
-}
-
-.hero-metric .accent-card p {
-    margin: 0;
-    color: rgba(255, 255, 255, 0.75);
+.hero-metric-card span {
     font-size: 0.95rem;
+    color: rgba(255, 255, 255, 0.8);
 }
 
 .badge-pill {

--- a/index.php
+++ b/index.php
@@ -38,32 +38,19 @@ include __DIR__ . '/partials/head.php';
                 </div>
             </div>
         </div>
-        <div class="hero-metric">
-            <div class="accent-card">
-                <h3>Experiență completă, gata de lansare.</h3>
-                <p>UX, conținut și tehnologie reunite într-un singur pachet digital.</p>
-                <strong>+68%</strong>
-                <span>creștere medie a timpului petrecut pe pagină după relansare</span>
-            </div>
-        </div>
-    </div>
-</section>
-<section class="stats py-5" aria-label="Rezultatele DesignToro">
-    <div class="container stats-grid">
-        <div class="stat-card">
-            <i class="fa-solid fa-briefcase text-primary display-6" aria-hidden="true"></i>
-            <span class="stat-value">225+</span>
-            <span class="stat-label">Lansări orchestrate</span>
-        </div>
-        <div class="stat-card">
-            <i class="fa-solid fa-face-smile text-primary display-6" aria-hidden="true"></i>
-            <span class="stat-value">213+</span>
-            <span class="stat-label">Branduri în prim-plan</span>
-        </div>
-        <div class="stat-card">
-            <i class="fa-solid fa-award text-primary display-6" aria-hidden="true"></i>
-            <span class="stat-value"><?php echo $experienceYears; ?>+</span>
-            <span class="stat-label">Peste <?php echo $experienceYears; ?> ani de experiență digitală</span>
+        <div class="hero-metric" role="list" aria-label="Rezultatele DesignToro">
+            <article class="accent-card hero-metric-card" role="listitem">
+                <strong>225+</strong>
+                <span>Lansări orchestrate</span>
+            </article>
+            <article class="accent-card hero-metric-card" role="listitem">
+                <strong>213+</strong>
+                <span>Branduri în prim-plan</span>
+            </article>
+            <article class="accent-card hero-metric-card" role="listitem">
+                <strong><?php echo $experienceYears; ?>+</strong>
+                <span>Peste <?php echo $experienceYears; ?> ani de experiență digitală</span>
+            </article>
         </div>
     </div>
 </section>


### PR DESCRIPTION
## Summary
- replace the hero metric spotlight with three accent cards highlighting key stats
- update the hero metric layout styling to support the new card grid

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d67babd5108327acd99015f25d8a3c