### PR TITLE
Update homepage metric highlights

### DIFF
--- a/index.php
+++ b/index.php
@@ -40,11 +40,11 @@ include __DIR__ . '/partials/head.php';
         </div>
         <div class="hero-metric" role="list" aria-label="Rezultatele DesignToro">
             <article class="accent-card hero-metric-card" role="listitem">
-                <strong>225+</strong>
-                <span>Lansări orchestrate</span>
+                <strong>1.300+</strong>
+                <span>Website-uri lansate</span>
             </article>
             <article class="accent-card hero-metric-card" role="listitem">
-                <strong>213+</strong>
+                <strong>700+</strong>
                 <span>Branduri în prim-plan</span>
             </article>
             <article class="accent-card hero-metric-card" role="listitem">


### PR DESCRIPTION
## Summary
- update the homepage hero metrics to highlight 1.300+ launched websites
- adjust the brand count metric to emphasize 700+ brands in the spotlight

## Testing
- no automated tests were run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68d681bc25e08327b9e02da9e5e0b4e3