### PR TITLE
Make desktop header sticky with blurred background

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -143,11 +143,8 @@ video {
 }
 
 .site-header {
-    position: sticky;
-    top: 0;
+    position: relative;
     z-index: 1000;
-    background: rgba(5, 5, 8, 0.8);
-    backdrop-filter: blur(18px);
     border-bottom: 1px solid var(--color-border);
 }
 
@@ -197,6 +194,14 @@ video {
 }
 
 @media (min-width: 992px) {
+    .site-header {
+        position: sticky;
+        top: 0;
+        background: rgba(8, 8, 14, 0.78);
+        border-bottom: 1px solid rgba(255, 255, 255, 0.12);
+        backdrop-filter: blur(18px);
+    }
+
     .navbar-links {
         justify-content: center;
         flex: 1;


### PR DESCRIPTION
## Summary
- adjust the header to remain static on mobile while enabling sticky positioning on desktop
- reuse the footer navigation's dark blurred background styling for the desktop header state

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d6831042708327a05c9c5d9c2d21f7