### PR TITLE
Adjust header background and add section scroll animations

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -146,6 +146,15 @@ video {
     position: relative;
     z-index: 1000;
     border-bottom: 1px solid var(--color-border);
+    background: #ff00002b;
+    backdrop-filter: none;
+    transition: background 0.3s ease, backdrop-filter 0.3s ease, border-color 0.3s ease;
+}
+
+.site-header.is-sticky {
+    background: rgba(8, 8, 14, 0.78);
+    border-bottom: 1px solid rgba(255, 255, 255, 0.12);
+    backdrop-filter: blur(18px);
 }
 
 .navbar {
@@ -197,9 +206,6 @@ video {
     .site-header {
         position: sticky;
         top: 0;
-        background: rgba(8, 8, 14, 0.78);
-        border-bottom: 1px solid rgba(255, 255, 255, 0.12);
-        backdrop-filter: blur(18px);
     }
 
     .navbar-links {

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -15,12 +15,28 @@
         { threshold: 0.2 }
     );
 
-    document
-        .querySelectorAll('.service-card, .portfolio-card, .portfolio-item, .pricing-card, .stat-card')
-        .forEach((el) => {
-            el.classList.add('reveal');
-            observer.observe(el);
-        });
+    const revealTargets = document.querySelectorAll(
+        'section, .service-card, .portfolio-card, .portfolio-item, .pricing-card, .stat-card'
+    );
+
+    revealTargets.forEach((el) => {
+        el.classList.add('reveal');
+        observer.observe(el);
+    });
+
+    const siteHeader = document.querySelector('.site-header');
+    if (siteHeader) {
+        const updateHeaderState = () => {
+            if (window.scrollY > 0) {
+                siteHeader.classList.add('is-sticky');
+            } else {
+                siteHeader.classList.remove('is-sticky');
+            }
+        };
+
+        updateHeaderState();
+        window.addEventListener('scroll', updateHeaderState, { passive: true });
+    }
 
     const filterButtons = document.querySelectorAll('.filter-button');
     const portfolioItems = document.querySelectorAll('.portfolio-item');


### PR DESCRIPTION
## Summary
- set the header background to the requested red tint while idle and restore the dark blurred styling once the page is scrolled
- reuse the reveal animation for every section to fade in as it enters the viewport and keep existing card animations

## Testing
- Not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d685f468c88327b4d10a49de27a346