### PR TITLE
Fix hero reveal animation offset

### DIFF
--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -16,10 +16,19 @@
     );
 
     const revealTargets = document.querySelectorAll(
-        'section, .service-card, .portfolio-card, .portfolio-item, .pricing-card, .stat-card'
+        'section:not(.hero), .service-card, .portfolio-card, .portfolio-item, .pricing-card, .stat-card'
     );
 
     revealTargets.forEach((el) => {
+        el.classList.add('reveal');
+        observer.observe(el);
+    });
+
+    const heroRevealTargets = document.querySelectorAll(
+        '.hero .hero-text > *, .hero .hero-metric, .hero .hero-metric .accent-card'
+    );
+
+    heroRevealTargets.forEach((el) => {
         el.classList.add('reveal');
         observer.observe(el);
     });


### PR DESCRIPTION
## Summary
- exclude the hero section from the global reveal animation to avoid the initial header gap
- apply the reveal effect to hero text and metric elements so only the content animates on load

## Testing
- not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68d688578bb08327a5cf663a6a0fc927