### PR TITLE
Disable sticky header on small screens

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -142,12 +142,6 @@ video {
 }
 
 .site-header {
-    position: -webkit-sticky;
-    position: sticky;
-    top: 0;
-    left: 0;
-    right: 0;
-    z-index: 1000;
     border-bottom: 1px solid var(--color-border);
     background: #ff00002b;
     backdrop-filter: none;
@@ -207,8 +201,12 @@ video {
 
 @media (min-width: 992px) {
     .site-header {
+        position: -webkit-sticky;
         position: sticky;
         top: 0;
+        left: 0;
+        right: 0;
+        z-index: 1000;
     }
 
     .navbar-links {

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -35,7 +35,16 @@
 
     const siteHeader = document.querySelector('.site-header');
     if (siteHeader) {
+        const stickyMediaQuery = window.matchMedia
+            ? window.matchMedia('(min-width: 992px)')
+            : null;
+
         const updateHeaderState = () => {
+            if (stickyMediaQuery && !stickyMediaQuery.matches) {
+                siteHeader.classList.remove('is-sticky');
+                return;
+            }
+
             if (window.scrollY > 0) {
                 siteHeader.classList.add('is-sticky');
             } else {
@@ -45,6 +54,16 @@
 
         updateHeaderState();
         window.addEventListener('scroll', updateHeaderState, { passive: true });
+
+        if (stickyMediaQuery) {
+            const handleMediaChange = () => updateHeaderState();
+
+            if (typeof stickyMediaQuery.addEventListener === 'function') {
+                stickyMediaQuery.addEventListener('change', handleMediaChange);
+            } else if (typeof stickyMediaQuery.addListener === 'function') {
+                stickyMediaQuery.addListener(handleMediaChange);
+            }
+        }
     }
 
     const filterButtons = document.querySelectorAll('.filter-button');


### PR DESCRIPTION
## Summary
- move sticky positioning styles for the header into the desktop media query so it no longer sticks on mobile
- wrap the JavaScript sticky state toggle in a desktop media query check to keep the effect limited to larger screens

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d6a122fe80832781d0bf92148fbe4f