### PR TITLE
Add interactive flip details for pricing packages

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -1104,14 +1104,44 @@ video {
 
 .pricing-card {
     position: relative;
+    perspective: 1800px;
+    cursor: pointer;
+    outline: none;
+}
+
+.pricing-card.popular {
+    transform: translateY(-10px);
+}
+
+.pricing-card-inner {
+    position: relative;
+    display: grid;
+    transform-style: preserve-3d;
+    transition: transform 0.65s cubic-bezier(0.19, 1, 0.22, 1);
+    min-height: 100%;
+}
+
+.pricing-card.is-flipped .pricing-card-inner {
+    transform: rotateY(180deg);
+}
+
+.pricing-card-face {
+    grid-area: 1 / 1;
     padding: 2.5rem 2rem;
     border-radius: 24px;
     background: var(--color-card);
+    border: 1px solid var(--color-border);
     box-shadow: var(--shadow-soft);
     display: flex;
     flex-direction: column;
     gap: 1.5rem;
-    border: 1px solid var(--color-border);
+    backface-visibility: hidden;
+    position: relative;
+}
+
+.pricing-card-back {
+    transform: rotateY(180deg);
+    gap: 1rem;
 }
 
 .pricing-card ul {
@@ -1125,7 +1155,7 @@ video {
 .pricing-card .badge {
     position: absolute;
     top: 1.5rem;
-    right: 1.5rem;
+    left: 1.5rem;
     background: var(--gradient-accent);
     color: #fff;
     font-size: 0.75rem;
@@ -1135,10 +1165,85 @@ video {
     letter-spacing: 0.08em;
 }
 
-.pricing-card.popular {
-    border: 1px solid rgba(229, 9, 20, 0.55);
-    transform: translateY(-10px);
+.pricing-card .info-toggle {
+    position: absolute;
+    top: 1.5rem;
+    right: 1.5rem;
+    width: 2.5rem;
+    height: 2.5rem;
+    border-radius: 999px;
+    border: 1px solid var(--color-border);
+    background: rgba(255, 255, 255, 0.04);
+    color: var(--color-muted);
+    font-weight: 600;
+    font-size: 0.95rem;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    cursor: pointer;
+    transition: background 0.3s ease, color 0.3s ease, border-color 0.3s ease;
+}
+
+.pricing-card .info-toggle:hover,
+.pricing-card .info-toggle:focus {
+    background: rgba(229, 9, 20, 0.12);
+    border-color: rgba(229, 9, 20, 0.4);
+    color: #fff;
+}
+
+.pricing-card .info-back {
+    align-self: flex-start;
+    padding: 0.6rem 1.4rem;
+    border-radius: 999px;
+    border: 1px solid var(--color-border);
+    background: transparent;
+    color: var(--color-text);
+    font-weight: 600;
+    letter-spacing: 0.02em;
+    text-transform: uppercase;
+    cursor: pointer;
+    transition: background 0.3s ease, color 0.3s ease, border-color 0.3s ease;
+}
+
+.pricing-card .info-back:hover,
+.pricing-card .info-back:focus {
+    background: rgba(229, 9, 20, 0.18);
+    border-color: rgba(229, 9, 20, 0.35);
+}
+
+.pricing-card-back h3 {
+    margin: 0;
+    font-size: 1.1rem;
+}
+
+.pricing-card-back p {
+    margin: 0;
+    color: var(--color-muted);
+}
+
+.pricing-card.popular .pricing-card-face {
+    border-color: rgba(229, 9, 20, 0.55);
+}
+
+.pricing-card.popular:not(.is-flipped) .pricing-card-front,
+.pricing-card.popular.is-flipped .pricing-card-back {
     box-shadow: 0 32px 65px rgba(229, 9, 20, 0.25);
+}
+
+.pricing-card.popular:not(.is-flipped) .pricing-card-back,
+.pricing-card.popular.is-flipped .pricing-card-front {
+    box-shadow: var(--shadow-soft);
+}
+
+.pricing-card:focus-visible .pricing-card-front,
+.pricing-card:focus-visible .pricing-card-back {
+    box-shadow: 0 0 0 3px rgba(229, 9, 20, 0.35), var(--shadow-soft);
+}
+
+@media (prefers-reduced-motion: reduce) {
+    .pricing-card-inner {
+        transition-duration: 0s;
+    }
 }
 
 .special-offer {

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -94,6 +94,75 @@
         });
     });
 
+    const pricingCards = document.querySelectorAll('[data-pricing-card]');
+
+    pricingCards.forEach((card) => {
+        const front = card.querySelector('.pricing-card-front');
+        const back = card.querySelector('.pricing-card-back');
+        const toggleButton = card.querySelector('[data-info-toggle]');
+
+        const setState = (flipped) => {
+            card.classList.toggle('is-flipped', flipped);
+            if (front) {
+                front.setAttribute('aria-hidden', flipped ? 'true' : 'false');
+            }
+            if (back) {
+                back.setAttribute('aria-hidden', flipped ? 'false' : 'true');
+            }
+            if (toggleButton) {
+                toggleButton.setAttribute('aria-expanded', flipped ? 'true' : 'false');
+            }
+        };
+
+        const toggleState = () => {
+            setState(!card.classList.contains('is-flipped'));
+        };
+
+        card.addEventListener('click', (event) => {
+            const target = event.target;
+
+            if (target.closest('.btn')) {
+                return;
+            }
+
+            if (target.closest('[data-info-close]')) {
+                event.preventDefault();
+                setState(false);
+                return;
+            }
+
+            if (target.closest('[data-info-toggle]')) {
+                event.preventDefault();
+                toggleState();
+                return;
+            }
+
+            if (!target.closest('.pricing-card-face')) {
+                return;
+            }
+
+            toggleState();
+        });
+
+        card.addEventListener('keydown', (event) => {
+            if (event.key === 'Escape') {
+                setState(false);
+                return;
+            }
+
+            if (event.target !== card) {
+                return;
+            }
+
+            if (event.key === 'Enter' || event.key === ' ') {
+                event.preventDefault();
+                toggleState();
+            }
+        });
+
+        setState(false);
+    });
+
     const recaptchaSiteKey = window.RECAPTCHA_SITE_KEY;
     const enableRecaptchaBadge = (auto = false) => {
         document.body.classList.add('show-recaptcha');

--- a/pachete.php
+++ b/pachete.php
@@ -15,61 +15,146 @@ include __DIR__ . '/partials/head.php';
 </section>
 <section class="pricing py-5" aria-label="Pachete de servicii">
     <div class="container pricing-grid">
-        <article class="pricing-card">
-            <h2>Starter Premiere</h2>
-            <p class="pricing-tag">Ideal pentru start-up-uri</p>
-            <ul>
-                <li>Landing page scenarizat pentru conversie rapidă</li>
-                <li>Design one-page cu animații ușoare</li>
-                <li>Copywriting de bază și integrare formulare</li>
-                <li>Implementare analytics &amp; heatmaps</li>
-            </ul>
-            <button class="btn btn-secondary" data-scroll="contact">Cere ofertă</button>
+        <article class="pricing-card" data-pricing-card tabindex="0" aria-label="Detalii pachet Starter Premiere">
+            <div class="pricing-card-inner">
+                <div class="pricing-card-face pricing-card-front" aria-hidden="false">
+                    <button class="info-toggle" type="button" data-info-toggle aria-expanded="false" aria-label="Vezi explicații ușor de înțeles">
+                        <span aria-hidden="true">i</span>
+                    </button>
+                    <h2>Starter Premiere</h2>
+                    <p class="pricing-tag">Ideal pentru start-up-uri</p>
+                    <ul>
+                        <li>Landing page scenarizat pentru conversie rapidă</li>
+                        <li>Design one-page cu animații ușoare</li>
+                        <li>Copywriting de bază și integrare formulare</li>
+                        <li>Implementare analytics &amp; heatmaps</li>
+                    </ul>
+                    <button class="btn btn-secondary" data-scroll="contact">Cere ofertă</button>
+                </div>
+                <div class="pricing-card-face pricing-card-back" aria-hidden="true">
+                    <h3>Pe scurt</h3>
+                    <p>Starter Premiere este pachetul potrivit dacă vrei să lansezi rapid un site clar și ușor de urmărit.</p>
+                    <ul>
+                        <li>Construim o singură pagină care explică pe înțelesul tuturor cine ești și ce oferi.</li>
+                        <li>Textele și imaginile sunt alese pentru a ghida vizitatorul spre acțiunea dorită.</li>
+                        <li>Primești instrumente simple de monitorizare ca să știi câți oameni ajung pe site.</li>
+                    </ul>
+                    <button class="info-back" type="button" data-info-close>Înapoi la detalii</button>
+                </div>
+            </div>
         </article>
-        <article class="pricing-card popular">
-            <div class="badge">Cel mai ales</div>
-            <h2>Spotlight</h2>
-            <p class="pricing-tag">Pentru branduri în creștere</p>
-            <ul>
-                <li>Website multipage cu UI orientat spre conversie</li>
-                <li>SEO on-page, content calendar și blog integrat</li>
-                <li>Automatizări lead nurturing &amp; e-mail marketing</li>
-                <li>Suport dedicat în primele 60 de zile</li>
-            </ul>
-            <button class="btn btn-accent" data-scroll="contact">Cere ofertă</button>
+        <article class="pricing-card popular" data-pricing-card tabindex="0" aria-label="Detalii pachet Spotlight">
+            <div class="pricing-card-inner">
+                <div class="pricing-card-face pricing-card-front" aria-hidden="false">
+                    <div class="badge">Cel mai ales</div>
+                    <button class="info-toggle" type="button" data-info-toggle aria-expanded="false" aria-label="Vezi explicații ușor de înțeles">
+                        <span aria-hidden="true">i</span>
+                    </button>
+                    <h2>Spotlight</h2>
+                    <p class="pricing-tag">Pentru branduri în creștere</p>
+                    <ul>
+                        <li>Website multipage cu UI orientat spre conversie</li>
+                        <li>SEO on-page, content calendar și blog integrat</li>
+                        <li>Automatizări lead nurturing &amp; e-mail marketing</li>
+                        <li>Suport dedicat în primele 60 de zile</li>
+                    </ul>
+                    <button class="btn btn-accent" data-scroll="contact">Cere ofertă</button>
+                </div>
+                <div class="pricing-card-face pricing-card-back" aria-hidden="true">
+                    <h3>Pe scurt</h3>
+                    <p>Spotlight este pentru brandurile care cresc și vor să își spună povestea pe mai multe pagini.</p>
+                    <ul>
+                        <li>Structurăm site-ul pe secțiuni clare pentru servicii, produse și articole.</li>
+                        <li>Te ajutăm să apari în căutările relevante și îți oferim un plan de conținut lunar.</li>
+                        <li>Automatizările țin legătura cu potențialii clienți și îți economisesc timp.</li>
+                    </ul>
+                    <button class="info-back" type="button" data-info-close>Înapoi la detalii</button>
+                </div>
+            </div>
         </article>
-        <article class="pricing-card">
-            <h2>Prime Release</h2>
-            <p class="pricing-tag">Pentru companii enterprise</p>
-            <ul>
-                <li>Experiențe digitale custom și arhitectură complexă</li>
-                <li>Integrare CRM, membership și marketing automation</li>
-                <li>Optimizare conversii continuă &amp; growth sprints</li>
-                <li>Consultanță CX și raportare avansată</li>
-            </ul>
-            <button class="btn btn-secondary" data-scroll="contact">Cere ofertă</button>
+        <article class="pricing-card" data-pricing-card tabindex="0" aria-label="Detalii pachet Prime Release">
+            <div class="pricing-card-inner">
+                <div class="pricing-card-face pricing-card-front" aria-hidden="false">
+                    <button class="info-toggle" type="button" data-info-toggle aria-expanded="false" aria-label="Vezi explicații ușor de înțeles">
+                        <span aria-hidden="true">i</span>
+                    </button>
+                    <h2>Prime Release</h2>
+                    <p class="pricing-tag">Pentru companii enterprise</p>
+                    <ul>
+                        <li>Experiențe digitale custom și arhitectură complexă</li>
+                        <li>Integrare CRM, membership și marketing automation</li>
+                        <li>Optimizare conversii continuă &amp; growth sprints</li>
+                        <li>Consultanță CX și raportare avansată</li>
+                    </ul>
+                    <button class="btn btn-secondary" data-scroll="contact">Cere ofertă</button>
+                </div>
+                <div class="pricing-card-face pricing-card-back" aria-hidden="true">
+                    <h3>Pe scurt</h3>
+                    <p>Prime Release este gândit pentru echipe mari cu procese complexe și multe integrări digitale.</p>
+                    <ul>
+                        <li>Construim experiențe personalizate care țin cont de fiecare etapă a clientului.</li>
+                        <li>Legăm site-ul de CRM, zone cu acces pe bază de cont sau abonamente fără bătăi de cap.</li>
+                        <li>Optimizările și rapoartele recurente te ajută să iei decizii bazate pe date reale.</li>
+                    </ul>
+                    <button class="info-back" type="button" data-info-close>Înapoi la detalii</button>
+                </div>
+            </div>
         </article>
     </div>
 </section>
 <section class="pricing py-5" aria-label="Pachete de mentenanță și social media">
     <div class="container pricing-grid maintenance">
-        <article class="pricing-card">
-            <h2>Mentenanță &amp; Support</h2>
-            <ul>
-                <li>Monitorizare uptime, securitate și backup-uri automate</li>
-                <li>Actualizări lunare platformă și componente</li>
-                <li>Raportare de performanță și recomandări</li>
-            </ul>
-            <button class="btn btn-secondary" data-scroll="contact">Solicită pachet</button>
+        <article class="pricing-card" data-pricing-card tabindex="0" aria-label="Detalii pachet Mentenanță și Support">
+            <div class="pricing-card-inner">
+                <div class="pricing-card-face pricing-card-front" aria-hidden="false">
+                    <button class="info-toggle" type="button" data-info-toggle aria-expanded="false" aria-label="Vezi explicații ușor de înțeles">
+                        <span aria-hidden="true">i</span>
+                    </button>
+                    <h2>Mentenanță &amp; Support</h2>
+                    <ul>
+                        <li>Monitorizare uptime, securitate și backup-uri automate</li>
+                        <li>Actualizări lunare platformă și componente</li>
+                        <li>Raportare de performanță și recomandări</li>
+                    </ul>
+                    <button class="btn btn-secondary" data-scroll="contact">Solicită pachet</button>
+                </div>
+                <div class="pricing-card-face pricing-card-back" aria-hidden="true">
+                    <h3>Pe scurt</h3>
+                    <p>Pachetul de mentenanță te scapă de grija actualizărilor și a problemelor tehnice neașteptate.</p>
+                    <ul>
+                        <li>Monitorizăm constant site-ul și intervenim rapid dacă apare o eroare.</li>
+                        <li>Actualizăm platforma la timp și păstrăm copii de siguranță.</li>
+                        <li>Primești rapoarte pe înțelesul tău despre ce s-a lucrat.</li>
+                    </ul>
+                    <button class="info-back" type="button" data-info-close>Înapoi la detalii</button>
+                </div>
+            </div>
         </article>
-        <article class="pricing-card">
-            <h2>Social Media Showrunner</h2>
-            <ul>
-                <li>Strategie editorială, grilă de conținut și tone of voice</li>
-                <li>Producție creativă pentru social media și asset-uri animate</li>
-                <li>Campanii plătite și raportări detaliate</li>
-            </ul>
-            <button class="btn btn-secondary" data-scroll="contact">Solicită pachet</button>
+        <article class="pricing-card" data-pricing-card tabindex="0" aria-label="Detalii pachet Social Media Showrunner">
+            <div class="pricing-card-inner">
+                <div class="pricing-card-face pricing-card-front" aria-hidden="false">
+                    <button class="info-toggle" type="button" data-info-toggle aria-expanded="false" aria-label="Vezi explicații ușor de înțeles">
+                        <span aria-hidden="true">i</span>
+                    </button>
+                    <h2>Social Media Showrunner</h2>
+                    <ul>
+                        <li>Strategie editorială, grilă de conținut și tone of voice</li>
+                        <li>Producție creativă pentru social media și asset-uri animate</li>
+                        <li>Campanii plătite și raportări detaliate</li>
+                    </ul>
+                    <button class="btn btn-secondary" data-scroll="contact">Solicită pachet</button>
+                </div>
+                <div class="pricing-card-face pricing-card-back" aria-hidden="true">
+                    <h3>Pe scurt</h3>
+                    <p>Social Media Showrunner este pentru brandurile care vor o prezență constantă și coerentă.</p>
+                    <ul>
+                        <li>Primești un plan editorial simplu care arată ce se postează și când.</li>
+                        <li>Creăm vizualuri și animații adaptate fiecărei platforme.</li>
+                        <li>Analizăm campaniile plătite și optimizăm mesajele lună de lună.</li>
+                    </ul>
+                    <button class="info-back" type="button" data-info-close>Înapoi la detalii</button>
+                </div>
+            </div>
         </article>
     </div>
 </section>


### PR DESCRIPTION
## Summary
- add front/back faces to each pricing card with an info toggle and simplified explanations
- update the pricing styles to support the new flipping animation and info controls
- wire up JavaScript handlers so cards flip on click or keyboard and update accessibility attributes

## Testing
- php -l pachete.php

------
https://chatgpt.com/codex/tasks/task_e_68d6a44876ac8327a0ec2b3ebcea7283