### PR TITLE
Adjust pricing card spacing for better readability

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -1139,6 +1139,10 @@ video {
     position: relative;
 }
 
+.pricing-card-front {
+    padding-top: 4.5rem;
+}
+
 .pricing-card-back {
     transform: rotateY(180deg);
     gap: 1rem;


### PR DESCRIPTION
## Summary
- increase the top padding on pricing card fronts to provide more room between badges, icons, and headings

## Testing
- No automated tests were run (CSS-only change)


------
https://chatgpt.com/codex/tasks/task_e_68d6b25932d08327a6ce0e03bd6a33ab