### PR TITLE
Add informational prompt to first pricing card

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -1195,6 +1195,40 @@ video {
     color: #fff;
 }
 
+.pricing-card .info-notice {
+    position: absolute;
+    top: 1.25rem;
+    right: 4.5rem;
+    padding: 0.35rem 0.75rem;
+    border-radius: 999px;
+    background: rgba(5, 5, 8, 0.8);
+    color: var(--color-muted);
+    font-size: 0.72rem;
+    letter-spacing: 0.02em;
+    text-transform: uppercase;
+    opacity: 0;
+    visibility: hidden;
+    transform: translateY(-6px);
+    transition: opacity 0.3s ease, transform 0.3s ease, visibility 0.3s ease;
+    pointer-events: none;
+    box-shadow: 0 18px 38px rgba(0, 0, 0, 0.35);
+    backdrop-filter: blur(8px);
+    border: 1px solid rgba(255, 255, 255, 0.08);
+}
+
+.pricing-card .info-notice.is-visible {
+    opacity: 1;
+    visibility: visible;
+    transform: translateY(0);
+}
+
+@media (max-width: 640px) {
+    .pricing-card .info-notice {
+        right: 1.5rem;
+        top: 4rem;
+    }
+}
+
 .pricing-card .info-back {
     align-self: flex-start;
     padding: 0.6rem 1.4rem;

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -163,6 +163,64 @@
         setState(false);
     });
 
+    const pricingInfoPrompt = document.getElementById('pricing-info-prompt');
+    const firstPricingToggle = document.querySelector('[data-pricing-card] [data-info-toggle]');
+
+    if (pricingInfoPrompt && firstPricingToggle) {
+        const PROMPT_STORAGE_KEY = 'pricingInfoPromptShownAt';
+        const PROMPT_INTERVAL = 24 * 60 * 60 * 1000;
+        const PROMPT_DELAY = 2000;
+        const PROMPT_DURATION = 10000;
+
+        let lastShownTimestamp = 0;
+
+        try {
+            const storedTimestamp = localStorage.getItem(PROMPT_STORAGE_KEY);
+            if (storedTimestamp) {
+                lastShownTimestamp = parseInt(storedTimestamp, 10) || 0;
+            }
+        } catch (error) {
+            lastShownTimestamp = 0;
+        }
+
+        const now = Date.now();
+        const canShowPrompt = !lastShownTimestamp || now - lastShownTimestamp >= PROMPT_INTERVAL;
+
+        const hidePrompt = () => {
+            pricingInfoPrompt.classList.remove('is-visible');
+            pricingInfoPrompt.setAttribute('aria-hidden', 'true');
+        };
+
+        if (canShowPrompt) {
+            window.setTimeout(() => {
+                pricingInfoPrompt.classList.add('is-visible');
+                pricingInfoPrompt.setAttribute('aria-hidden', 'false');
+
+                try {
+                    localStorage.setItem(PROMPT_STORAGE_KEY, String(Date.now()));
+                } catch (error) {
+                    /* localStorage might be unavailable; ignore */
+                }
+
+                window.setTimeout(hidePrompt, PROMPT_DURATION);
+            }, PROMPT_DELAY);
+        }
+
+        const dismissPrompt = () => {
+            if (pricingInfoPrompt.classList.contains('is-visible')) {
+                hidePrompt();
+            }
+        };
+
+        firstPricingToggle.addEventListener('click', dismissPrompt);
+        firstPricingToggle.addEventListener('focus', dismissPrompt);
+        firstPricingToggle.addEventListener('keydown', (event) => {
+            if (event.key === 'Escape') {
+                dismissPrompt();
+            }
+        });
+    }
+
     const recaptchaSiteKey = window.RECAPTCHA_SITE_KEY;
     const enableRecaptchaBadge = (auto = false) => {
         document.body.classList.add('show-recaptcha');

--- a/pachete.php
+++ b/pachete.php
@@ -21,6 +21,9 @@ include __DIR__ . '/partials/head.php';
                     <button class="info-toggle" type="button" data-info-toggle aria-expanded="false" aria-label="Vezi explicații ușor de înțeles">
                         <span aria-hidden="true">i</span>
                     </button>
+                    <div class="info-notice" id="pricing-info-prompt" role="status" aria-live="polite" aria-hidden="true">
+                        <span>apasa aici pentru informatii</span>
+                    </div>
                     <h2>Starter Premiere</h2>
                     <p class="pricing-tag">Ideal pentru start-up-uri</p>
                     <ul>


### PR DESCRIPTION
## Summary
- add a discreet informational notice near the first pricing card info toggle
- style the notice for dark theme layouts and animate its appearance
- display the notice for 10 seconds via JavaScript and limit it to once every 24 hours

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d6c4d62ae483279ca605d740a7d162