### PR TITLE
Adjust pricing info notice placement

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -1203,7 +1203,7 @@ video {
 .pricing-card .info-notice {
     position: absolute;
     top: 1.25rem;
-    right: 4.5rem;
+    right: calc(1.5rem + 2.5rem + 0.85rem);
     padding: 0.35rem 0.75rem;
     border-radius: 999px;
     background: rgba(5, 5, 8, 0.8);
@@ -1221,6 +1221,32 @@ video {
     border: 1px solid rgba(255, 255, 255, 0.08);
 }
 
+.pricing-card .info-notice::before,
+.pricing-card .info-notice::after {
+    content: "";
+    position: absolute;
+    top: 50%;
+    transform: translateY(-50%);
+    width: 0;
+    height: 0;
+    pointer-events: none;
+}
+
+.pricing-card .info-notice::before {
+    right: -10px;
+    border-top: 9px solid transparent;
+    border-bottom: 9px solid transparent;
+    border-left: 10px solid rgba(255, 255, 255, 0.08);
+    filter: drop-shadow(0 12px 18px rgba(0, 0, 0, 0.35));
+}
+
+.pricing-card .info-notice::after {
+    right: -8px;
+    border-top: 8px solid transparent;
+    border-bottom: 8px solid transparent;
+    border-left: 8px solid rgba(5, 5, 8, 0.8);
+}
+
 .pricing-card .info-notice.is-visible {
     opacity: 1;
     visibility: visible;
@@ -1229,8 +1255,8 @@ video {
 
 @media (max-width: 640px) {
     .pricing-card .info-notice {
-        right: 1.5rem;
         top: 4rem;
+        right: calc(1.5rem + 2.5rem + 0.65rem);
     }
 }
 


### PR DESCRIPTION
## Summary
- shift the pricing info prompt badge to the left of the info icon
- add a bordered pointer arrow that targets the icon for clearer association
- keep responsive spacing aligned with the new layout

## Testing
- No automated tests were run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68d6c6856d5083279fe99172817e20ff