### PR TITLE
Adjust info notice placement on pricing cards

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -1255,7 +1255,7 @@ video {
 
 @media (max-width: 640px) {
     .pricing-card .info-notice {
-        top: 4rem;
+        top: 1rem;
         right: calc(1.5rem + 2.5rem + 0.65rem);
     }
 }


### PR DESCRIPTION
## Summary
- move the pricing card info notice higher on mobile screens to avoid overlapping the card title

## Testing
- php -S 0.0.0.0:8000

------
https://chatgpt.com/codex/tasks/task_e_68d6c7c313b883278f35ed181dde37a1