### PR TITLE
Rename pricing page to preturi and add offer modal

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -1258,6 +1258,17 @@ video {
         top: 1rem;
         right: calc(1.5rem + 2.5rem + 0.65rem);
     }
+
+    .offer-modal__dialog {
+        padding: 1.5rem;
+        border-radius: 20px;
+    }
+}
+
+@media (max-width: 480px) {
+    .offer-modal {
+        padding: 1rem;
+    }
 }
 
 .pricing-card .info-back {
@@ -1488,6 +1499,97 @@ video {
 .form-feedback.error {
     background: rgba(229, 9, 20, 0.18);
     color: #ff6f79;
+}
+
+.delivery-note {
+    margin: -0.35rem 0 0;
+    font-size: 0.78rem;
+    color: var(--color-muted);
+}
+
+.offer-modal {
+    position: fixed;
+    inset: 0;
+    display: none;
+    align-items: center;
+    justify-content: center;
+    padding: 1.5rem;
+    background: rgba(5, 5, 8, 0.6);
+    backdrop-filter: blur(8px);
+    z-index: 1200;
+}
+
+.offer-modal.is-visible {
+    display: flex;
+}
+
+.offer-modal__backdrop {
+    position: absolute;
+    inset: 0;
+    background: rgba(5, 5, 8, 0.7);
+}
+
+.offer-modal__dialog {
+    position: relative;
+    width: min(640px, 100%);
+    max-height: 90vh;
+    overflow-y: auto;
+    border-radius: 24px;
+    background: var(--color-card);
+    border: 1px solid var(--color-border);
+    box-shadow: var(--shadow-soft);
+    padding: clamp(1.75rem, 4vw, 2.75rem);
+}
+
+.offer-modal__close {
+    position: absolute;
+    top: 1.25rem;
+    right: 1.25rem;
+    width: 2.5rem;
+    height: 2.5rem;
+    border-radius: 999px;
+    border: 1px solid var(--color-border);
+    background: transparent;
+    color: var(--color-muted);
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    cursor: pointer;
+    transition: background 0.3s ease, color 0.3s ease, border-color 0.3s ease;
+}
+
+.offer-modal__close:hover,
+.offer-modal__close:focus {
+    background: rgba(229, 9, 20, 0.16);
+    color: #fff;
+    border-color: rgba(229, 9, 20, 0.4);
+}
+
+.offer-modal__content h2 {
+    margin-bottom: 0.35rem;
+}
+
+.offer-modal__subtitle {
+    margin-top: 0;
+    margin-bottom: 1.25rem;
+    color: var(--color-muted);
+}
+
+.offer-form {
+    display: grid;
+    gap: 1.1rem;
+}
+
+.offer-form .form-group {
+    margin: 0;
+}
+
+.offer-form .btn {
+    width: 100%;
+}
+
+body.offer-modal-open {
+    overflow: hidden;
 }
 
 .honeypot {

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -271,6 +271,73 @@
         }
     }
 
+    const offerModal = document.querySelector('[data-offer-modal]');
+    if (offerModal) {
+        const offerOpenButtons = document.querySelectorAll('[data-offer-modal-open]');
+        const planField = offerModal.querySelector('#offer-plan-field');
+        const nameField = offerModal.querySelector('#offer-name');
+        const closeSelectors = '[data-offer-modal-close]';
+
+        const setAriaState = (isOpen) => {
+            offerModal.setAttribute('aria-hidden', isOpen ? 'false' : 'true');
+            if (isOpen) {
+                document.body.classList.add('offer-modal-open');
+            } else {
+                document.body.classList.remove('offer-modal-open');
+            }
+        };
+
+        const openOfferModal = (plan) => {
+            if (planField && typeof plan === 'string') {
+                planField.value = plan;
+            }
+
+            offerModal.classList.add('is-visible');
+            setAriaState(true);
+
+            window.setTimeout(() => {
+                if (nameField && typeof nameField.focus === 'function') {
+                    nameField.focus();
+                }
+            }, 50);
+        };
+
+        const closeOfferModal = () => {
+            offerModal.classList.remove('is-visible');
+            setAriaState(false);
+        };
+
+        if (offerModal.classList.contains('is-visible')) {
+            setAriaState(true);
+            window.setTimeout(() => {
+                if (nameField && typeof nameField.focus === 'function') {
+                    nameField.focus();
+                }
+            }, 50);
+        }
+
+        offerOpenButtons.forEach((button) => {
+            button.addEventListener('click', (event) => {
+                event.preventDefault();
+                const plan = button.getAttribute('data-offer-plan') || button.textContent.trim();
+                openOfferModal(plan);
+            });
+        });
+
+        offerModal.addEventListener('click', (event) => {
+            if (event.target.closest(closeSelectors)) {
+                event.preventDefault();
+                closeOfferModal();
+            }
+        });
+
+        document.addEventListener('keydown', (event) => {
+            if (event.key === 'Escape' && offerModal.classList.contains('is-visible')) {
+                closeOfferModal();
+            }
+        });
+    }
+
     const stickyFooterNav = document.querySelector('.mobile-footer-nav');
     if (stickyFooterNav) {
         const updateStickyNavVisibility = () => {

--- a/includes/offer-handler.php
+++ b/includes/offer-handler.php
@@ -1,0 +1,102 @@
+<?php
+require_once __DIR__ . '/../config/secretkey.php';
+
+function offer_sanitize_input(string $value): string
+{
+    $value = trim($value);
+    $value = strip_tags($value);
+    return htmlspecialchars($value, ENT_QUOTES, 'UTF-8');
+}
+
+function offer_verify_recaptcha(string $token, string $remoteIp): bool
+{
+    if (RECAPTCHA_SECRET_KEY === 'YOUR_SECRET_KEY_HERE') {
+        return false;
+    }
+
+    $response = file_get_contents(
+        'https://www.google.com/recaptcha/api/siteverify?secret='
+        . urlencode(RECAPTCHA_SECRET_KEY)
+        . '&response=' . urlencode($token)
+        . '&remoteip=' . urlencode($remoteIp)
+    );
+
+    if (!$response) {
+        return false;
+    }
+
+    $result = json_decode($response, true);
+    return is_array($result) && ($result['success'] ?? false) === true && ($result['score'] ?? 0) >= 0.5;
+}
+
+function handle_offer_request(): array
+{
+    $errors = [];
+    $honeypot = $_POST['company'] ?? '';
+    if (!empty($honeypot)) {
+        $errors[] = 'Formular invalid.';
+        return ['success' => false, 'errors' => $errors];
+    }
+
+    $name = offer_sanitize_input($_POST['name'] ?? '');
+    $email = filter_var($_POST['email'] ?? '', FILTER_SANITIZE_EMAIL);
+    $phone = offer_sanitize_input($_POST['phone'] ?? '');
+    $details = offer_sanitize_input($_POST['details'] ?? '');
+    $plan = offer_sanitize_input($_POST['offer_plan'] ?? '');
+    $token = $_POST['g-recaptcha-response'] ?? '';
+
+    if ($name === '') {
+        $errors[] = 'Numele este obligatoriu.';
+    }
+
+    if ($phone === '') {
+        $errors[] = 'Numărul de telefon este obligatoriu.';
+    }
+
+    if ($email === '' || !filter_var($email, FILTER_VALIDATE_EMAIL)) {
+        $errors[] = 'Adresa de email nu este validă.';
+    }
+
+    if ($details === '') {
+        $errors[] = 'Detaliile despre proiect sunt obligatorii.';
+    }
+
+    if ($token === '') {
+        $errors[] = 'Verificarea reCAPTCHA a eșuat.';
+    } elseif (!offer_verify_recaptcha($token, $_SERVER['REMOTE_ADDR'] ?? '')) {
+        $errors[] = 'Nu am putut valida reCAPTCHA.';
+    }
+
+    if (!empty($errors)) {
+        return ['success' => false, 'errors' => $errors];
+    }
+
+    $subject = 'Cerere de ofertă nouă - DesignToro.ro';
+    $bodyLines = [
+        "Nume: {$name}",
+        "Telefon: {$phone}",
+        "Email: {$email}",
+    ];
+
+    if ($plan !== '') {
+        $bodyLines[] = "Pachet de interes: {$plan}";
+    }
+
+    $bodyLines[] = "Detalii:\n{$details}";
+    $body = implode("\n", $bodyLines);
+    $headers = 'From: no-reply@designtoro.ro' . "\r\n" . 'Reply-To: ' . $email;
+
+    $mailSent = false;
+    if (function_exists('mail')) {
+        $mailSent = mail('office@designtoro.ro', $subject, $body, $headers);
+    }
+
+    if (!$mailSent) {
+        return [
+            'success' => false,
+            'errors' => ['Momentan nu putem trimite mesajul. Vă rugăm să ne contactați telefonic.'],
+        ];
+    }
+
+    return ['success' => true, 'errors' => []];
+}

--- a/index.php
+++ b/index.php
@@ -116,7 +116,7 @@ include __DIR__ . '/partials/head.php';
                 <div class="service-icon"><i class="fa-solid fa-palette" aria-hidden="true"></i></div>
                 <h3>Branding &amp; Content Studio</h3>
                 <p>Identități vizuale, ghiduri de comunicare și campanii de conținut care vând.</p>
-                <a class="link-arrow" href="/servicii#branding">Vezi pachetele</a>
+                <a class="link-arrow" href="/preturi">Vezi prețurile</a>
             </article>
         </div>
     </div>

--- a/partials/footer.php
+++ b/partials/footer.php
@@ -13,7 +13,7 @@
             <ul>
                 <li><a href="/">Acasă</a></li>
                 <li><a href="/servicii">Servicii</a></li>
-                <li><a href="/pachete">Pachete</a></li>
+                <li><a href="/preturi">Prețuri</a></li>
                 <li><a href="/portofoliu">Portofoliu</a></li>
                 <li><a href="/contact">Contact</a></li>
             </ul>
@@ -52,10 +52,10 @@ $mobileFooterNavItems = [
         'icon' => 'fa-solid fa-layer-group',
         'label' => 'Servicii',
     ],
-    'pachete' => [
-        'href' => '/pachete',
-        'icon' => 'fa-solid fa-box-open',
-        'label' => 'Pachete',
+    'preturi' => [
+        'href' => '/preturi',
+        'icon' => 'fa-solid fa-tags',
+        'label' => 'Prețuri',
     ],
     'portofoliu' => [
         'href' => '/portofoliu',

--- a/partials/header.php
+++ b/partials/header.php
@@ -6,7 +6,7 @@
                 <ul class="navbar-links" id="primary-menu">
                     <li class="nav-item"><a href="/" class="nav-link">Acasă</a></li>
                     <li class="nav-item"><a href="/servicii" class="nav-link">Servicii</a></li>
-                    <li class="nav-item"><a href="/pachete" class="nav-link">Pachete</a></li>
+                    <li class="nav-item"><a href="/preturi" class="nav-link">Prețuri</a></li>
                     <li class="nav-item"><a href="/portofoliu" class="nav-link">Portofoliu</a></li>
                     <li class="nav-item"><a href="/contact" class="nav-link">Contact</a></li>
                 </ul>

--- a/preturi.php
+++ b/preturi.php
@@ -1,19 +1,33 @@
 <?php
 require_once __DIR__ . '/includes/security-headers.php';
 $pageTitle = 'Prețuri Creare Site și Pachete Marketing | DesignToro';
-$pageDescription = 'Compară pachetele DesignToro pentru web design, marketing și mentenanță. Alege soluția potrivită afacerii tale.';
+$pageDescription = 'Compară prețurile și pachetele DesignToro pentru web design, marketing și mentenanță. Alege soluția potrivită afacerii tale.';
 $pageKeywords = 'preț creare site, pachet web design, ofertă site prezentare, cost mentenanță site, prețuri marketing';
-$pageUrl = 'https://www.designtoro.ro/pachete';
-$currentPage = 'pachete';
+$pageUrl = 'https://www.designtoro.ro/preturi';
+$currentPage = 'preturi';
+$offerResponse = null;
+$offerModalShouldOpen = false;
+$bodyClasses = $bodyClasses ?? [];
+
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    require_once __DIR__ . '/includes/offer-handler.php';
+    $offerResponse = handle_offer_request();
+    $offerModalShouldOpen = true;
+
+    if (empty($offerResponse['success'])) {
+        $bodyClasses[] = 'show-recaptcha';
+    }
+}
+
 include __DIR__ . '/partials/head.php';
 ?>
 <section class="page-hero py-5" aria-labelledby="pricing-hero">
     <div class="container narrow text-center">
-        <h1 id="pricing-hero">Pachete create pentru lansări digitale performante.</h1>
+        <h1 id="pricing-hero">Prețuri transparente pentru lansări digitale performante.</h1>
         <p>Transparență totală, beneficii clare și flexibilitate pentru branduri aflate la start sau în expansiune.</p>
     </div>
 </section>
-<section class="pricing py-5" aria-label="Pachete de servicii">
+<section class="pricing py-5" aria-label="Prețuri servicii web design">
     <div class="container pricing-grid">
         <article class="pricing-card" data-pricing-card tabindex="0" aria-label="Detalii pachet StartUp">
             <div class="pricing-card-inner">
@@ -32,17 +46,18 @@ include __DIR__ . '/partials/head.php';
                         <li>Interfață complet adaptabilă pe mobil, tabletă și desktop</li>
                         <li>Panou de administrare intuitiv și e-mailuri profesionale personalizate</li>
                         <li>Securitate standard: SSL și backup-uri zilnice</li>
-                        <li>Termen de livrare: 5-10 zile lucrătoare</li>
                     </ul>
-                    <button class="btn btn-secondary" data-scroll="contact">Cere ofertă</button>
+                    <button class="btn btn-secondary" data-offer-modal-open data-offer-plan="StartUp">Cere ofertă</button>
+                    <p class="delivery-note">Termen estimat de livrare: 5-10 zile lucrătoare</p>
                 </div>
                 <div class="pricing-card-face pricing-card-back" aria-hidden="true">
                     <h3>Pe scurt</h3>
                     <p>StartUp este fundația potrivită dacă vrei o prezență online rapidă, clară și construită corect încă de la început.</p>
                     <ul>
-                        <li>Primești o arhitectură de bază cu design original și elemente vizuale personalizate brandului tău.</li>
-                        <li>Administrarea conținutului este simplă datorită panoului intuitiv și adreselor de e-mail dedicate.</li>
-                        <li>Securitatea este asigurată prin SSL, backup-uri zilnice și găzduire performantă.</li>
+                        <li>Site-ul este găzduit pe serverul nostru privat la care au acces doar clienții DesignToro – nu îl împarți cu mii de site-uri, ca în găzduirea de masă.</li>
+                        <li>Primești o arhitectură clară cu design original, copy de start și elemente vizuale aliniate identității brandului.</li>
+                        <li>Administrarea conținutului rămâne intuitivă datorită tutorialelor dedicate și adreselor de e-mail profesionale.</li>
+                        <li>Securitatea este activ monitorizată prin SSL, backup-uri zilnice testate și alerte de uptime.</li>
                     </ul>
                     <button class="info-back" type="button" data-info-close>Înapoi la detalii</button>
                 </div>
@@ -62,17 +77,18 @@ include __DIR__ . '/partials/head.php';
                         <li>Structură extinsă până la 7 pagini și identitate vizuală cu logo vectorial</li>
                         <li>Optimizare SEO on-page și conformitate GDPR de bază</li>
                         <li>Integrare Google Analytics, Facebook Pixel și soluții de chat</li>
-                        <li>Termen de livrare: 10-20 de zile lucrătoare</li>
                     </ul>
-                    <button class="btn btn-accent" data-scroll="contact">Cere ofertă</button>
+                    <button class="btn btn-accent" data-offer-modal-open data-offer-plan="Business Plus">Cere ofertă</button>
+                    <p class="delivery-note">Termen estimat de livrare: 10-20 de zile lucrătoare</p>
                 </div>
                 <div class="pricing-card-face pricing-card-back" aria-hidden="true">
                     <h3>Pe scurt</h3>
                     <p>Business Plus este soluția completă pentru afaceri care vor să transforme vizitatorii în clienți.</p>
                     <ul>
-                        <li>Textele persuasive și imaginile atent selectate construiesc încredere și diferențiază brandul.</li>
-                        <li>Logo-ul și identitatea vizuală consolidează mesajul pe fiecare pagină a site-ului.</li>
-                        <li>Instrumentele de analiză și chat oferă vizibilitate asupra performanței și sprijină conversia.</li>
+                        <li>Textele persuasive și sesiunile de interviu ne ajută să traducem expertiza ta în mesaje clare care convertesc.</li>
+                        <li>Logo-ul, paleta cromatică și sistemul vizual sunt livrate în format editabil, gata pentru orice material viitor.</li>
+                        <li>Instrumentele de analiză și chat oferă vizibilitate asupra performanței și sprijină conversia în timp real.</li>
+                        <li>Infrastructura privată asigură resurse dedicate – site-ul tău nu împarte CPU sau memorie cu sute de proiecte străine.</li>
                     </ul>
                     <button class="info-back" type="button" data-info-close>Înapoi la detalii</button>
                 </div>
@@ -91,17 +107,18 @@ include __DIR__ . '/partials/head.php';
                         <li>Strategie SEO avansată: cercetare de cuvinte cheie și optimizare pentru fiecare pagină</li>
                         <li>Consultanță pentru strategie de conținut și infrastructură performantă globală</li>
                         <li>Optimizare Google Business Profile și materiale de brand dedicate</li>
-                        <li>Termen de livrare: 20-40 de zile lucrătoare</li>
                     </ul>
-                    <button class="btn btn-secondary" data-scroll="contact">Cere ofertă</button>
+                    <button class="btn btn-secondary" data-offer-modal-open data-offer-plan="Executive">Cere ofertă</button>
+                    <p class="delivery-note">Termen estimat de livrare: 20-40 de zile lucrătoare</p>
                 </div>
                 <div class="pricing-card-face pricing-card-back" aria-hidden="true">
                     <h3>Pe scurt</h3>
                     <p>Executive este pachetul pentru companii care vor autoritate, performanță și vizibilitate constantă.</p>
                     <ul>
-                        <li>Arhitectura extinsă a site-ului susține un conținut variat, cu accent pe autoritate și conversie.</li>
-                        <li>Strategia SEO avansată și infrastructura globală oferă viteză, protecție și poziționare solidă.</li>
-                        <li>Dominanța locală și materialele de brand întăresc prezența companiei în fața clienților cheie.</li>
+                        <li>Arhitectura extinsă a site-ului susține campanii de conținut, lead magnets și integrarea CRM-ului.</li>
+                        <li>Strategia SEO avansată și infrastructura multi-region asigură încărcare rapidă din orice țară și protecție DDoS.</li>
+                        <li>Workshop-urile trimestriale și materialele de brand dedicate alimentează constant echipa de vânzări.</li>
+                        <li>Găzduirea pe server dedicat DesignToro păstrează resursele doar pentru brandul tău și menține uptime de 99,9%.</li>
                     </ul>
                     <button class="info-back" type="button" data-info-close>Înapoi la detalii</button>
                 </div>
@@ -123,15 +140,16 @@ include __DIR__ . '/partials/head.php';
                         <li>Actualizări lunare platformă și componente</li>
                         <li>Raportare de performanță și recomandări</li>
                     </ul>
-                    <button class="btn btn-secondary" data-scroll="contact">Solicită pachet</button>
+                    <button class="btn btn-secondary" data-offer-modal-open data-offer-plan="Mentenanță &amp; Support">Solicită pachet</button>
                 </div>
                 <div class="pricing-card-face pricing-card-back" aria-hidden="true">
                     <h3>Pe scurt</h3>
                     <p>Pachetul de mentenanță te scapă de grija actualizărilor și a problemelor tehnice neașteptate.</p>
                     <ul>
-                        <li>Monitorizăm constant site-ul și intervenim rapid dacă apare o eroare.</li>
-                        <li>Actualizăm platforma la timp și păstrăm copii de siguranță.</li>
-                        <li>Primești rapoarte pe înțelesul tău despre ce s-a lucrat.</li>
+                        <li>Monitorizăm constant site-ul și intervenim rapid dacă apare o eroare sau un plugin vulnerabil.</li>
+                        <li>Actualizăm platforma la timp, testăm compatibilitatea și păstrăm copii de siguranță în locații separate.</li>
+                        <li>Primești rapoarte clare despre fiecare intervenție și recomandări acționabile pentru următoarea lună.</li>
+                        <li>Serverul privat rămâne optimizat doar pentru clienții noștri, astfel uptime-ul rămâne peste 99,9%.</li>
                     </ul>
                     <button class="info-back" type="button" data-info-close>Înapoi la detalii</button>
                 </div>
@@ -149,15 +167,16 @@ include __DIR__ . '/partials/head.php';
                         <li>Producție creativă pentru social media și asset-uri animate</li>
                         <li>Campanii plătite și raportări detaliate</li>
                     </ul>
-                    <button class="btn btn-secondary" data-scroll="contact">Solicită pachet</button>
+                    <button class="btn btn-secondary" data-offer-modal-open data-offer-plan="Social Media Showrunner">Solicită pachet</button>
                 </div>
                 <div class="pricing-card-face pricing-card-back" aria-hidden="true">
                     <h3>Pe scurt</h3>
                     <p>Social Media Showrunner este pentru brandurile care vor o prezență constantă și coerentă.</p>
                     <ul>
-                        <li>Primești un plan editorial simplu care arată ce se postează și când.</li>
-                        <li>Creăm vizualuri și animații adaptate fiecărei platforme.</li>
-                        <li>Analizăm campaniile plătite și optimizăm mesajele lună de lună.</li>
+                        <li>Primești un plan editorial simplu care arată ce se postează și când, plus guideline-uri de răspuns rapid.</li>
+                        <li>Creăm vizualuri, animații și template-uri reutilizabile astfel încât echipa ta să posteze fără blocaje.</li>
+                        <li>Analizăm campaniile plătite și optimizăm mesajele lună de lună, cu focus pe leaduri și vânzări.</li>
+                        <li>Sincronizăm constant comunicarea cu landing page-urile găzduite pe serverul nostru privat pentru un parcurs fluent.</li>
                     </ul>
                     <button class="info-back" type="button" data-info-close>Înapoi la detalii</button>
                 </div>
@@ -165,6 +184,91 @@ include __DIR__ . '/partials/head.php';
         </article>
     </div>
 </section>
+<?php $offerSuccess = $offerResponse && !empty($offerResponse['success']); ?>
+<div
+    class="offer-modal<?= $offerModalShouldOpen ? ' is-visible' : ''; ?><?= $offerSuccess ? ' is-success' : ''; ?>"
+    data-offer-modal
+    aria-hidden="<?= $offerModalShouldOpen ? 'false' : 'true'; ?>"
+    role="dialog"
+    aria-modal="true"
+    aria-labelledby="offer-modal-title"
+>
+    <div class="offer-modal__backdrop" data-offer-modal-close aria-hidden="true"></div>
+    <div class="offer-modal__dialog" role="document">
+        <button class="offer-modal__close" type="button" data-offer-modal-close aria-label="Închide formularul">
+            <i class="fa-solid fa-xmark" aria-hidden="true"></i>
+        </button>
+        <div class="offer-modal__content" data-offer-modal-content>
+            <h2 id="offer-modal-title">Cere o ofertă personalizată</h2>
+            <p class="offer-modal__subtitle">Completează detaliile esențiale și revenim cu propunerea potrivită în maximum o zi lucrătoare.</p>
+            <?php if ($offerResponse): ?>
+                <div class="form-feedback <?= !empty($offerResponse['success']) ? 'success' : 'error'; ?>">
+                    <?php if (!empty($offerResponse['success'])): ?>
+                        <p>Îți mulțumim! Cererea a fost trimisă. Un specialist DesignToro te va contacta în scurt timp.</p>
+                    <?php else: ?>
+                        <ul>
+                            <?php foreach ($offerResponse['errors'] as $error): ?>
+                                <li><?= $error; ?></li>
+                            <?php endforeach; ?>
+                        </ul>
+                    <?php endif; ?>
+                </div>
+            <?php endif; ?>
+            <form class="offer-form" id="offer-form" method="post" action="/preturi" novalidate>
+                <div class="form-group">
+                    <label for="offer-name" class="form-label">Nume *</label>
+                    <input
+                        type="text"
+                        id="offer-name"
+                        name="name"
+                        class="form-control"
+                        value="<?= htmlspecialchars($_POST['name'] ?? '', ENT_QUOTES, 'UTF-8'); ?>"
+                        required
+                    >
+                </div>
+                <div class="form-group">
+                    <label for="offer-phone" class="form-label">Număr de telefon *</label>
+                    <input
+                        type="tel"
+                        id="offer-phone"
+                        name="phone"
+                        class="form-control"
+                        value="<?= htmlspecialchars($_POST['phone'] ?? '', ENT_QUOTES, 'UTF-8'); ?>"
+                        required
+                    >
+                </div>
+                <div class="form-group">
+                    <label for="offer-email" class="form-label">Email *</label>
+                    <input
+                        type="email"
+                        id="offer-email"
+                        name="email"
+                        class="form-control"
+                        value="<?= htmlspecialchars($_POST['email'] ?? '', ENT_QUOTES, 'UTF-8'); ?>"
+                        required
+                    >
+                </div>
+                <div class="form-group">
+                    <label for="offer-details" class="form-label">Detalii despre site / proiect *</label>
+                    <textarea
+                        id="offer-details"
+                        name="details"
+                        rows="5"
+                        class="form-control"
+                        required
+                    ><?= htmlspecialchars($_POST['details'] ?? '', ENT_QUOTES, 'UTF-8'); ?></textarea>
+                </div>
+                <div class="form-group honeypot">
+                    <label for="offer-company">Companie</label>
+                    <input type="text" id="offer-company" name="company" autocomplete="off">
+                </div>
+                <input type="hidden" name="offer_plan" id="offer-plan-field" value="<?= htmlspecialchars($_POST['offer_plan'] ?? '', ENT_QUOTES, 'UTF-8'); ?>">
+                <input type="hidden" name="g-recaptcha-response" id="recaptcha-token">
+                <button class="btn btn-accent" type="submit">Trimite cererea</button>
+            </form>
+        </div>
+    </div>
+</div>
 <section class="special-offer" aria-labelledby="offer-title">
     <div class="container special-grid">
         <div>


### PR DESCRIPTION
## Summary
- rename the public pricing page to `/preturi` and update navigation labels/icons to match
- add an in-page offer request modal with required contact details, CAPTCHA and optional plan prefill
- enrich pricing card content and display delivery timelines beneath each call-to-action button

## Testing
- php -l preturi.php
- php -l partials/header.php
- php -l partials/footer.php
- php -l index.php
- php -l includes/offer-handler.php

------
https://chatgpt.com/codex/tasks/task_e_68d6ec92afd08327885366c387669572