### PR TITLE
Animate offer modal with staggered fields

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -1517,16 +1517,25 @@ video {
     background: rgba(5, 5, 8, 0.6);
     backdrop-filter: blur(8px);
     z-index: 1200;
+    opacity: 0;
+    transition: opacity 0.35s ease;
 }
 
 .offer-modal.is-visible {
     display: flex;
+    opacity: 1;
 }
 
 .offer-modal__backdrop {
     position: absolute;
     inset: 0;
     background: rgba(5, 5, 8, 0.7);
+    opacity: 0;
+    transition: opacity 0.3s ease;
+}
+
+.offer-modal.is-visible .offer-modal__backdrop {
+    opacity: 1;
 }
 
 .offer-modal__dialog {
@@ -1539,6 +1548,13 @@ video {
     border: 1px solid var(--color-border);
     box-shadow: var(--shadow-soft);
     padding: clamp(1.75rem, 4vw, 2.75rem);
+    opacity: 0;
+    transform: translateY(24px) scale(0.98);
+    will-change: opacity, transform;
+}
+
+.offer-modal.is-visible .offer-modal__dialog {
+    animation: offerModalIn 0.45s cubic-bezier(0.23, 1, 0.32, 1) forwards;
 }
 
 .offer-modal__close {
@@ -1586,6 +1602,67 @@ video {
 
 .offer-form .btn {
     width: 100%;
+}
+
+body:not(.no-js) [data-offer-animate] {
+    opacity: 0;
+    transform: translateY(16px);
+    will-change: opacity, transform;
+}
+
+body:not(.no-js) [data-offer-animate].is-animated {
+    animation: offerFieldFadeUp 0.4s ease forwards;
+    animation-delay: var(--offer-animate-delay, 0ms);
+}
+
+@keyframes offerModalIn {
+    0% {
+        opacity: 0;
+        transform: translateY(24px) scale(0.98);
+    }
+
+    100% {
+        opacity: 1;
+        transform: translateY(0) scale(1);
+    }
+}
+
+@keyframes offerFieldFadeUp {
+    0% {
+        opacity: 0;
+        transform: translateY(16px);
+    }
+
+    100% {
+        opacity: 1;
+        transform: translateY(0);
+    }
+}
+
+@media (prefers-reduced-motion: reduce) {
+    .offer-modal {
+        transition: none;
+    }
+
+    .offer-modal__backdrop {
+        transition: none;
+        opacity: 1;
+    }
+
+    .offer-modal.is-visible .offer-modal__dialog {
+        animation: none;
+        opacity: 1;
+        transform: none;
+    }
+
+    body:not(.no-js) [data-offer-animate] {
+        opacity: 1;
+        transform: none;
+    }
+
+    body:not(.no-js) [data-offer-animate].is-animated {
+        animation: none;
+    }
 }
 
 body.offer-modal-open {

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -277,6 +277,34 @@
         const planField = offerModal.querySelector('#offer-plan-field');
         const nameField = offerModal.querySelector('#offer-name');
         const closeSelectors = '[data-offer-modal-close]';
+        const animatedElements = offerModal.querySelectorAll('[data-offer-animate]');
+        const prefersReducedMotion = typeof window.matchMedia === 'function'
+            ? window.matchMedia('(prefers-reduced-motion: reduce)')
+            : { matches: false };
+
+        const animateOfferFields = () => {
+            if (!animatedElements.length) {
+                return;
+            }
+
+            animatedElements.forEach((element) => {
+                element.classList.remove('is-animated');
+                element.style.removeProperty('--offer-animate-delay');
+            });
+
+            window.requestAnimationFrame(() => {
+                animatedElements.forEach((element, index) => {
+                    const delayStep = prefersReducedMotion.matches ? 0 : 120;
+                    const delay = delayStep * index;
+
+                    if (delay) {
+                        element.style.setProperty('--offer-animate-delay', `${delay}ms`);
+                    }
+
+                    element.classList.add('is-animated');
+                });
+            });
+        };
 
         const setAriaState = (isOpen) => {
             offerModal.setAttribute('aria-hidden', isOpen ? 'false' : 'true');
@@ -294,6 +322,7 @@
 
             offerModal.classList.add('is-visible');
             setAriaState(true);
+            animateOfferFields();
 
             window.setTimeout(() => {
                 if (nameField && typeof nameField.focus === 'function') {
@@ -309,6 +338,7 @@
 
         if (offerModal.classList.contains('is-visible')) {
             setAriaState(true);
+            animateOfferFields();
             window.setTimeout(() => {
                 if (nameField && typeof nameField.focus === 'function') {
                     nameField.focus();
@@ -336,6 +366,14 @@
                 closeOfferModal();
             }
         });
+
+        if (typeof prefersReducedMotion.addEventListener === 'function') {
+            prefersReducedMotion.addEventListener('change', () => {
+                if (offerModal.classList.contains('is-visible')) {
+                    animateOfferFields();
+                }
+            });
+        }
     }
 
     const stickyFooterNav = document.querySelector('.mobile-footer-nav');

--- a/preturi.php
+++ b/preturi.php
@@ -215,7 +215,7 @@ include __DIR__ . '/partials/head.php';
                 </div>
             <?php endif; ?>
             <form class="offer-form" id="offer-form" method="post" action="/preturi" novalidate>
-                <div class="form-group">
+                <div class="form-group" data-offer-animate>
                     <label for="offer-name" class="form-label">Nume *</label>
                     <input
                         type="text"
@@ -226,7 +226,7 @@ include __DIR__ . '/partials/head.php';
                         required
                     >
                 </div>
-                <div class="form-group">
+                <div class="form-group" data-offer-animate>
                     <label for="offer-phone" class="form-label">Număr de telefon *</label>
                     <input
                         type="tel"
@@ -237,7 +237,7 @@ include __DIR__ . '/partials/head.php';
                         required
                     >
                 </div>
-                <div class="form-group">
+                <div class="form-group" data-offer-animate>
                     <label for="offer-email" class="form-label">Email *</label>
                     <input
                         type="email"
@@ -248,7 +248,7 @@ include __DIR__ . '/partials/head.php';
                         required
                     >
                 </div>
-                <div class="form-group">
+                <div class="form-group" data-offer-animate>
                     <label for="offer-details" class="form-label">Detalii despre site / proiect *</label>
                     <textarea
                         id="offer-details"
@@ -264,7 +264,7 @@ include __DIR__ . '/partials/head.php';
                 </div>
                 <input type="hidden" name="offer_plan" id="offer-plan-field" value="<?= htmlspecialchars($_POST['offer_plan'] ?? '', ENT_QUOTES, 'UTF-8'); ?>">
                 <input type="hidden" name="g-recaptcha-response" id="recaptcha-token">
-                <button class="btn btn-accent" type="submit">Trimite cererea</button>
+                <button class="btn btn-accent" type="submit" data-offer-animate>Trimite cererea</button>
             </form>
         </div>
     </div>


### PR DESCRIPTION
## Summary
- animate the offer modal overlay and dialog with smooth fade-in transitions
- stagger the form fields with data attributes and JavaScript-triggered fade-up animations
- add reduced motion fallbacks so the form remains usable without animations

## Testing
- php -l preturi.php

------
https://chatgpt.com/codex/tasks/task_e_68d71665ade883278406e5e8a4664ddb