### PR TITLE
Delay offer modal field animation for smoother entry

### DIFF
--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -294,8 +294,9 @@
 
             window.requestAnimationFrame(() => {
                 animatedElements.forEach((element, index) => {
-                    const delayStep = prefersReducedMotion.matches ? 0 : 120;
-                    const delay = delayStep * index;
+                    const delayBase = prefersReducedMotion.matches ? 0 : 1000;
+                    const delayStep = prefersReducedMotion.matches ? 0 : 180;
+                    const delay = delayBase + (delayStep * index);
 
                     if (delay) {
                         element.style.setProperty('--offer-animate-delay', `${delay}ms`);


### PR DESCRIPTION
## Summary
- add a 1s base delay before animating offer modal fields so the fade-up begins after the popup appears
- increase the stagger between fields to 180ms while respecting users with reduced motion preferences

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d7184c37888327b379585c1b4c7665