### PR TITLE
Add consent checkbox to forms and refine offer modal animations

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -1485,6 +1485,31 @@ video {
     box-shadow: 0 0 0 0.15rem rgba(229, 9, 20, 0.3);
 }
 
+.form-group.form-consent {
+    grid-template-columns: auto 1fr;
+    align-items: flex-start;
+    gap: 0.75rem;
+}
+
+.form-group.form-consent input[type="checkbox"] {
+    width: 1.15rem;
+    height: 1.15rem;
+    margin-top: 0.2rem;
+    accent-color: var(--color-accent);
+}
+
+.form-group.form-consent label {
+    font-weight: 400;
+    font-size: 0.95rem;
+    line-height: 1.5;
+}
+
+.form-group.form-consent a {
+    color: var(--color-accent);
+    text-decoration: underline;
+    text-decoration-thickness: 1px;
+}
+
 .form-feedback {
     border-radius: 16px;
     padding: 1rem 1.25rem;

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -294,7 +294,7 @@
 
             window.requestAnimationFrame(() => {
                 animatedElements.forEach((element, index) => {
-                    const delayBase = prefersReducedMotion.matches ? 0 : 1000;
+                    const delayBase = prefersReducedMotion.matches ? 0 : 250;
                     const delayStep = prefersReducedMotion.matches ? 0 : 180;
                     const delay = delayBase + (delayStep * index);
 

--- a/contact.php
+++ b/contact.php
@@ -62,6 +62,20 @@ include __DIR__ . '/partials/head.php';
                     <label for="message" class="form-label">Mesaj *</label>
                     <textarea id="message" name="message" rows="5" class="form-control" required></textarea>
                 </div>
+                <div class="form-group form-consent">
+                    <input
+                        type="checkbox"
+                        id="contact-terms"
+                        name="terms"
+                        value="1"
+                        required
+                        <?= isset($_POST['terms']) ? 'checked' : ''; ?>
+                    >
+                    <label for="contact-terms">
+                        Sunt de acord cu <a href="/termeni-si-conditii" target="_blank" rel="noopener">Termenii și condițiile</a>
+                        și cu <a href="/politica-de-confidentialitate" target="_blank" rel="noopener">Politica de confidențialitate</a>.
+                    </label>
+                </div>
                 <input type="hidden" name="g-recaptcha-response" id="recaptcha-token">
                 <button class="btn btn-accent" type="submit">Trimite mesajul</button>
             </form>

--- a/includes/contact-handler.php
+++ b/includes/contact-handler.php
@@ -42,6 +42,7 @@ function handle_contact_form(): array
     $email = filter_var($_POST['email'] ?? '', FILTER_SANITIZE_EMAIL);
     $phone = sanitize_input($_POST['phone'] ?? '');
     $message = sanitize_input($_POST['message'] ?? '');
+    $termsAccepted = isset($_POST['terms']) && $_POST['terms'] === '1';
     $token = $_POST['g-recaptcha-response'] ?? '';
 
     if ($name === '') {
@@ -54,6 +55,10 @@ function handle_contact_form(): array
 
     if ($message === '') {
         $errors[] = 'Mesajul este obligatoriu.';
+    }
+
+    if (!$termsAccepted) {
+        $errors[] = 'Trebuie să accepți Termenii și condițiile și Politica de confidențialitate.';
     }
 
     if ($token === '') {

--- a/includes/offer-handler.php
+++ b/includes/offer-handler.php
@@ -43,6 +43,7 @@ function handle_offer_request(): array
     $phone = offer_sanitize_input($_POST['phone'] ?? '');
     $details = offer_sanitize_input($_POST['details'] ?? '');
     $plan = offer_sanitize_input($_POST['offer_plan'] ?? '');
+    $termsAccepted = isset($_POST['terms']) && $_POST['terms'] === '1';
     $token = $_POST['g-recaptcha-response'] ?? '';
 
     if ($name === '') {
@@ -59,6 +60,10 @@ function handle_offer_request(): array
 
     if ($details === '') {
         $errors[] = 'Detaliile despre proiect sunt obligatorii.';
+    }
+
+    if (!$termsAccepted) {
+        $errors[] = 'Trebuie să accepți Termenii și condițiile și Politica de confidențialitate.';
     }
 
     if ($token === '') {

--- a/preturi.php
+++ b/preturi.php
@@ -199,10 +199,10 @@ include __DIR__ . '/partials/head.php';
             <i class="fa-solid fa-xmark" aria-hidden="true"></i>
         </button>
         <div class="offer-modal__content" data-offer-modal-content>
-            <h2 id="offer-modal-title">Cere o ofertă personalizată</h2>
-            <p class="offer-modal__subtitle">Completează detaliile esențiale și revenim cu propunerea potrivită în maximum o zi lucrătoare.</p>
+            <h2 id="offer-modal-title" data-offer-animate>Cere o ofertă personalizată</h2>
+            <p class="offer-modal__subtitle" data-offer-animate>Completează detaliile esențiale și revenim cu propunerea potrivită în maximum o zi lucrătoare.</p>
             <?php if ($offerResponse): ?>
-                <div class="form-feedback <?= !empty($offerResponse['success']) ? 'success' : 'error'; ?>">
+                <div class="form-feedback <?= !empty($offerResponse['success']) ? 'success' : 'error'; ?>" data-offer-animate>
                     <?php if (!empty($offerResponse['success'])): ?>
                         <p>Îți mulțumim! Cererea a fost trimisă. Un specialist DesignToro te va contacta în scurt timp.</p>
                     <?php else: ?>
@@ -261,6 +261,20 @@ include __DIR__ . '/partials/head.php';
                 <div class="form-group honeypot">
                     <label for="offer-company">Companie</label>
                     <input type="text" id="offer-company" name="company" autocomplete="off">
+                </div>
+                <div class="form-group form-consent" data-offer-animate>
+                    <input
+                        type="checkbox"
+                        id="offer-terms"
+                        name="terms"
+                        value="1"
+                        required
+                        <?= isset($_POST['terms']) ? 'checked' : ''; ?>
+                    >
+                    <label for="offer-terms">
+                        Sunt de acord cu <a href="/termeni-si-conditii" target="_blank" rel="noopener">Termenii și condițiile</a>
+                        și cu <a href="/politica-de-confidentialitate" target="_blank" rel="noopener">Politica de confidențialitate</a>.
+                    </label>
                 </div>
                 <input type="hidden" name="offer_plan" id="offer-plan-field" value="<?= htmlspecialchars($_POST['offer_plan'] ?? '', ENT_QUOTES, 'UTF-8'); ?>">
                 <input type="hidden" name="g-recaptcha-response" id="recaptcha-token">


### PR DESCRIPTION
## Summary
- delay the animated elements inside the offer modal by 250ms and animate the heading, subtitle, and feedback text.
- add a required terms and privacy consent checkbox to the offer and contact forms, including styling.
- validate the new consent field on the server for both offer and contact handlers.

## Testing
- php -l contact.php
- php -l preturi.php
- php -l includes/contact-handler.php
- php -l includes/offer-handler.php

------
https://chatgpt.com/codex/tasks/task_e_68d719463dc88327a5ce803b3f68cf41