### PR TITLE
Implement asynchronous forms with metadata and UI feedback

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -1510,20 +1510,94 @@ video {
     text-decoration-thickness: 1px;
 }
 
+.form-shell {
+    position: relative;
+}
+
+.contact-form.is-hidden,
+.offer-form.is-hidden {
+    display: none;
+}
+
+.form-success-message {
+    display: none;
+    align-items: flex-start;
+    gap: 1rem;
+    border-radius: 18px;
+    padding: 1.25rem 1.5rem;
+    background: rgba(46, 204, 113, 0.12);
+    color: #1d7a46;
+    border: 1px solid rgba(46, 204, 113, 0.35);
+    margin-bottom: 1.5rem;
+}
+
+.form-success-message.is-visible {
+    display: flex;
+}
+
+.form-success-icon {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 2.75rem;
+    height: 2.75rem;
+    border-radius: 999px;
+    background: rgba(46, 204, 113, 0.2);
+    color: #1abc9c;
+    font-size: 1.5rem;
+}
+
+.form-success-title {
+    font-weight: 600;
+    font-size: 1.1rem;
+    margin-bottom: 0.3rem;
+}
+
 .form-feedback {
+    display: none;
+    margin-bottom: 1rem;
     border-radius: 16px;
     padding: 1rem 1.25rem;
     font-weight: 500;
+    background: rgba(229, 9, 20, 0.14);
+    color: var(--color-accent);
+    border: 1px solid rgba(229, 9, 20, 0.35);
 }
 
-.form-feedback.success {
-    background: rgba(46, 204, 113, 0.15);
-    color: #7bed9f;
+.form-feedback.is-visible {
+    display: block;
 }
 
-.form-feedback.error {
-    background: rgba(229, 9, 20, 0.18);
-    color: #ff6f79;
+.form-feedback ul {
+    margin: 0;
+    padding-left: 1.2rem;
+}
+
+.form-error {
+    margin: 0.35rem 0 0;
+    font-size: 0.85rem;
+    color: var(--color-accent);
+    line-height: 1.4;
+}
+
+.form-error[hidden],
+.form-error:empty {
+    display: none;
+}
+
+.form-group.has-error .form-label,
+.form-group.has-error label {
+    color: var(--color-accent);
+}
+
+.form-group.has-error .form-control,
+.form-group.has-error textarea,
+.form-group.has-error input[type="text"],
+.form-group.has-error input[type="email"],
+.form-group.has-error input[type="tel"],
+.form-group.has-error input[type="checkbox"] {
+    border-color: rgba(229, 9, 20, 0.6);
+    box-shadow: 0 0 0 0.15rem rgba(229, 9, 20, 0.18);
 }
 
 .delivery-note {
@@ -1549,6 +1623,10 @@ video {
 .offer-modal.is-visible {
     display: flex;
     opacity: 1;
+}
+
+.offer-modal.is-closing {
+    pointer-events: none;
 }
 
 .offer-modal__backdrop {
@@ -1585,6 +1663,14 @@ video {
 
 .offer-modal.is-visible .offer-modal__dialog {
     animation: offerModalIn 0.45s cubic-bezier(0.23, 1, 0.32, 1) forwards;
+}
+
+.offer-modal.is-closing .offer-modal__backdrop {
+    animation: offerModalOutBackdrop 0.28s ease forwards;
+}
+
+.offer-modal.is-closing .offer-modal__dialog {
+    animation: offerModalOut 0.35s cubic-bezier(0.23, 1, 0.32, 1) forwards;
 }
 
 .offer-modal__close {
@@ -1654,6 +1740,28 @@ body:not(.no-js) [data-offer-animate].is-animated {
     100% {
         opacity: 1;
         transform: translateY(0) scale(1);
+    }
+}
+
+@keyframes offerModalOutBackdrop {
+    0% {
+        opacity: 1;
+    }
+
+    100% {
+        opacity: 0;
+    }
+}
+
+@keyframes offerModalOut {
+    0% {
+        opacity: 1;
+        transform: translateY(0) scale(1);
+    }
+
+    100% {
+        opacity: 0;
+        transform: translateY(18px) scale(0.96);
     }
 }
 

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -234,42 +234,63 @@
             delete document.body.dataset.recaptchaAuto;
         }
     };
-    const initializeRecaptcha = () => {
-        if (typeof grecaptcha === 'undefined' || !recaptchaSiteKey) {
+    const setRecaptchaTokenValue = (token) => {
+        document.querySelectorAll('[data-recaptcha-token]').forEach((field) => {
+            field.value = token || '';
+        });
+    };
+    let pendingRecaptchaRequest = null;
+    const requestRecaptchaToken = () => {
+        if (!recaptchaSiteKey || typeof grecaptcha === 'undefined') {
             enableRecaptchaBadge(true);
+            setRecaptchaTokenValue('');
+            return Promise.resolve(null);
+        }
+
+        if (pendingRecaptchaRequest) {
+            return pendingRecaptchaRequest;
+        }
+
+        pendingRecaptchaRequest = new Promise((resolve) => {
+            grecaptcha.ready(() => {
+                grecaptcha
+                    .execute(recaptchaSiteKey, { action: 'contact' })
+                    .then((token) => {
+                        setRecaptchaTokenValue(token);
+                        disableAutoRecaptchaBadge();
+                        pendingRecaptchaRequest = null;
+                        resolve(token);
+                    })
+                    .catch(() => {
+                        console.warn('Nu s-a putut genera tokenul reCAPTCHA.');
+                        enableRecaptchaBadge(true);
+                        setRecaptchaTokenValue('');
+                        pendingRecaptchaRequest = null;
+                        resolve(null);
+                    });
+            });
+        });
+
+        return pendingRecaptchaRequest;
+    };
+    const initializeRecaptcha = () => {
+        if (!recaptchaSiteKey) {
             return;
         }
 
-        grecaptcha.ready(() => {
-            grecaptcha
-                .execute(recaptchaSiteKey, { action: 'contact' })
-                .then((token) => {
-                    const tokenField = document.getElementById('recaptcha-token');
-                    if (tokenField) {
-                        tokenField.value = token;
-                    }
-                    disableAutoRecaptchaBadge();
-                })
-                .catch(() => {
-                    console.warn('Nu s-a putut genera tokenul reCAPTCHA.');
-                    enableRecaptchaBadge(true);
-                });
-        });
-    };
-
-    if (recaptchaSiteKey) {
         if (typeof grecaptcha !== 'undefined') {
-            initializeRecaptcha();
+            requestRecaptchaToken();
         } else {
+            enableRecaptchaBadge(true);
             window.addEventListener('load', () => {
                 if (typeof grecaptcha !== 'undefined') {
-                    initializeRecaptcha();
-                } else {
-                    enableRecaptchaBadge(true);
+                    requestRecaptchaToken();
                 }
             });
         }
-    }
+    };
+
+    initializeRecaptcha();
 
     const offerModal = document.querySelector('[data-offer-modal]');
     if (offerModal) {
@@ -281,6 +302,7 @@
         const prefersReducedMotion = typeof window.matchMedia === 'function'
             ? window.matchMedia('(prefers-reduced-motion: reduce)')
             : { matches: false };
+        const offerModalCloseDuration = prefersReducedMotion.matches ? 0 : 280;
 
         const animateOfferFields = () => {
             if (!animatedElements.length) {
@@ -321,6 +343,7 @@
                 planField.value = plan;
             }
 
+            offerModal.classList.remove('is-closing');
             offerModal.classList.add('is-visible');
             setAriaState(true);
             animateOfferFields();
@@ -333,8 +356,24 @@
         };
 
         const closeOfferModal = () => {
-            offerModal.classList.remove('is-visible');
+            if (!offerModal.classList.contains('is-visible')) {
+                setAriaState(false);
+                return;
+            }
+
+            if (prefersReducedMotion.matches) {
+                offerModal.classList.remove('is-visible');
+                offerModal.classList.remove('is-closing');
+                setAriaState(false);
+                return;
+            }
+
+            offerModal.classList.add('is-closing');
             setAriaState(false);
+            window.setTimeout(() => {
+                offerModal.classList.remove('is-visible');
+                offerModal.classList.remove('is-closing');
+            }, offerModalCloseDuration);
         };
 
         if (offerModal.classList.contains('is-visible')) {
@@ -376,6 +415,478 @@
             });
         }
     }
+
+    const fingerprintFields = document.querySelectorAll('[data-device-fingerprint]');
+    if (fingerprintFields.length) {
+        const fingerprintData = {
+            userAgent: navigator.userAgent,
+            language: navigator.language,
+            languages: Array.isArray(navigator.languages) ? navigator.languages : [],
+            platform: navigator.platform,
+            vendor: navigator.vendor,
+            screen: {
+                width: window.screen ? window.screen.width : undefined,
+                height: window.screen ? window.screen.height : undefined,
+                availWidth: window.screen ? window.screen.availWidth : undefined,
+                availHeight: window.screen ? window.screen.availHeight : undefined,
+                colorDepth: window.screen ? window.screen.colorDepth : undefined,
+                pixelRatio: window.devicePixelRatio
+            },
+            timezone: Intl.DateTimeFormat ? Intl.DateTimeFormat().resolvedOptions().timeZone : undefined,
+            timezoneOffset: new Date().getTimezoneOffset(),
+            hardwareConcurrency: navigator.hardwareConcurrency,
+            deviceMemory: navigator.deviceMemory,
+            maxTouchPoints: navigator.maxTouchPoints,
+            cookieEnabled: navigator.cookieEnabled,
+            referrer: document.referrer
+        };
+
+        let fingerprintString = '';
+        try {
+            fingerprintString = JSON.stringify(fingerprintData);
+        } catch (error) {
+            fingerprintString = '';
+        }
+
+        fingerprintFields.forEach((field) => {
+            field.value = fingerprintString;
+        });
+    }
+
+    const FORM_SUCCESS_STORAGE_PREFIX = 'dtFormSuccess:';
+    const FORM_SUCCESS_TTL = 24 * 60 * 60 * 1000;
+    const getStoredSuccessTimestamp = (key) => {
+        if (!key) {
+            return 0;
+        }
+
+        try {
+            const rawValue = localStorage.getItem(FORM_SUCCESS_STORAGE_PREFIX + key);
+            if (!rawValue) {
+                return 0;
+            }
+
+            const timestamp = parseInt(rawValue, 10);
+            if (!timestamp || Number.isNaN(timestamp)) {
+                localStorage.removeItem(FORM_SUCCESS_STORAGE_PREFIX + key);
+                return 0;
+            }
+
+            if (Date.now() - timestamp >= FORM_SUCCESS_TTL) {
+                localStorage.removeItem(FORM_SUCCESS_STORAGE_PREFIX + key);
+                return 0;
+            }
+
+            return timestamp;
+        } catch (error) {
+            return 0;
+        }
+    };
+    const storeSuccessTimestamp = (key) => {
+        if (!key) {
+            return;
+        }
+
+        try {
+            localStorage.setItem(FORM_SUCCESS_STORAGE_PREFIX + key, String(Date.now()));
+        } catch (error) {
+            /* localStorage may be unavailable */
+        }
+    };
+    const clearStoredSuccess = (key) => {
+        if (!key) {
+            return;
+        }
+
+        try {
+            localStorage.removeItem(FORM_SUCCESS_STORAGE_PREFIX + key);
+        } catch (error) {
+            /* ignore */
+        }
+    };
+
+    const phoneValidationMessages = {
+        invalidCharacters: 'Numărul de telefon poate conține doar cifre (și un singur + la început).',
+        invalidInternational: 'Numărul de telefon în format internațional trebuie să aibă între 6 și 14 cifre.',
+        invalidNational: 'Numărul de telefon trebuie să conțină exact 10 cifre.',
+        required: 'Numărul de telefon este obligatoriu.'
+    };
+
+    const validatePhoneValue = (value, isRequired) => {
+        const trimmed = value.trim();
+
+        if (!trimmed) {
+            if (isRequired) {
+                return { valid: false, message: phoneValidationMessages.required };
+            }
+
+            return { valid: true, message: '' };
+        }
+
+        const hasPlus = trimmed.startsWith('+');
+        const digits = hasPlus ? trimmed.slice(1) : trimmed;
+
+        if (!/^[0-9]*$/.test(digits) || digits.length === 0) {
+            return { valid: false, message: phoneValidationMessages.invalidCharacters };
+        }
+
+        if (hasPlus) {
+            if (digits.length < 6 || digits.length > 14) {
+                return { valid: false, message: phoneValidationMessages.invalidInternational };
+            }
+        } else if (digits.length !== 10) {
+            return { valid: false, message: phoneValidationMessages.invalidNational };
+        }
+
+        return { valid: true, message: '' };
+    };
+
+    const errorMessages = {
+        name: { required: 'Numele este obligatoriu.' },
+        email: {
+            required: 'Adresa de email este obligatorie.',
+            invalid: 'Adresa de email nu este validă.'
+        },
+        phone: {
+            required: phoneValidationMessages.required
+        },
+        message: { required: 'Mesajul este obligatoriu.' },
+        details: { required: 'Detaliile despre proiect sunt obligatorii.' },
+        terms: {
+            required: 'Trebuie să accepți Termenii și condițiile și Politica de confidențialitate.'
+        }
+    };
+
+    const asyncForms = document.querySelectorAll('[data-async-form]');
+    asyncForms.forEach((form) => {
+        const storageKey = form.getAttribute('data-success-storage-key');
+        const formWrapper = form.closest('[data-form-wrapper]');
+        const successContainer = formWrapper ? formWrapper.querySelector('[data-form-success]') : null;
+        const globalErrorContainer = form.querySelector('[data-form-global-error]');
+        const fieldErrorElements = new Map();
+        form.querySelectorAll('[data-field-error]').forEach((element) => {
+            const fieldName = element.getAttribute('data-field-error');
+            if (fieldName) {
+                fieldErrorElements.set(fieldName, element);
+            }
+        });
+
+        const hasActiveFieldErrors = () => {
+            for (const element of fieldErrorElements.values()) {
+                if (element.textContent && element.textContent.trim() !== '') {
+                    return true;
+                }
+            }
+            return false;
+        };
+
+        const showGlobalErrors = (messages) => {
+            if (!globalErrorContainer) {
+                return;
+            }
+
+            if (!messages || !messages.length) {
+                globalErrorContainer.innerHTML = '';
+                globalErrorContainer.hidden = true;
+                globalErrorContainer.classList.remove('is-visible');
+                return;
+            }
+
+            const list = document.createElement('ul');
+            messages.forEach((message) => {
+                const listItem = document.createElement('li');
+                listItem.textContent = message;
+                list.appendChild(listItem);
+            });
+
+            globalErrorContainer.innerHTML = '';
+            globalErrorContainer.appendChild(list);
+            globalErrorContainer.hidden = false;
+            globalErrorContainer.classList.add('is-visible');
+        };
+
+        const showFieldError = (name, message) => {
+            const errorElement = fieldErrorElements.get(name);
+            if (errorElement) {
+                errorElement.textContent = message;
+                errorElement.hidden = false;
+            }
+
+            const fields = form.elements[name];
+            if (!fields) {
+                return;
+            }
+
+            const fieldNodes = fields instanceof RadioNodeList ? Array.from(fields) : [fields];
+            fieldNodes.forEach((field) => {
+                const group = field.closest('.form-group');
+                if (group) {
+                    group.classList.add('has-error');
+                }
+            });
+        };
+
+        const clearFieldError = (name) => {
+            const errorElement = fieldErrorElements.get(name);
+            if (errorElement) {
+                errorElement.textContent = '';
+                errorElement.hidden = true;
+            }
+
+            const fields = form.elements[name];
+            if (!fields) {
+                return;
+            }
+
+            const fieldNodes = fields instanceof RadioNodeList ? Array.from(fields) : [fields];
+            fieldNodes.forEach((field) => {
+                const group = field.closest('.form-group');
+                if (group) {
+                    group.classList.remove('has-error');
+                }
+            });
+        };
+
+        const clearAllErrors = () => {
+            fieldErrorElements.forEach((_, key) => {
+                clearFieldError(key);
+            });
+            showGlobalErrors([]);
+        };
+
+        const validateField = (field) => {
+            if (!field || !field.name || field.disabled) {
+                return null;
+            }
+
+            const name = field.name;
+            const type = field.type;
+            const isCheckbox = type === 'checkbox';
+            const isRequired = field.required === true || field.getAttribute('required') !== null;
+            const value = isCheckbox ? field.checked : field.value.trim();
+            const fieldMessages = errorMessages[name] || {};
+
+            if (isCheckbox) {
+                if (isRequired && !field.checked) {
+                    return fieldMessages.required || 'Acest câmp este obligatoriu.';
+                }
+                return null;
+            }
+
+            if (isRequired && value === '') {
+                return fieldMessages.required || 'Acest câmp este obligatoriu.';
+            }
+
+            if (name === 'email' && value !== '') {
+                const emailPattern = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+                if (!emailPattern.test(value)) {
+                    return fieldMessages.invalid || 'Adresa de email nu este validă.';
+                }
+            }
+
+            if (name === 'phone') {
+                const validationResult = validatePhoneValue(field.value, isRequired);
+                if (!validationResult.valid) {
+                    return validationResult.message;
+                }
+            }
+
+            return null;
+        };
+
+        const validateForm = () => {
+            const fieldErrors = {};
+            Array.from(form.elements).forEach((element) => {
+                if (!(element instanceof HTMLElement)) {
+                    return;
+                }
+
+                if (!element.name || element.type === 'hidden' || element.type === 'submit' || element.type === 'button') {
+                    return;
+                }
+
+                const message = validateField(element);
+                if (message) {
+                    fieldErrors[element.name] = message;
+                }
+            });
+
+            return fieldErrors;
+        };
+
+        const setFormVisibility = (hidden) => {
+            if (hidden) {
+                form.classList.add('is-hidden');
+                form.setAttribute('aria-hidden', 'true');
+            } else {
+                form.classList.remove('is-hidden');
+                form.removeAttribute('aria-hidden');
+            }
+        };
+
+        const setSuccessVisibility = (visible) => {
+            if (!successContainer) {
+                return;
+            }
+
+            successContainer.hidden = !visible;
+            successContainer.classList.toggle('is-visible', visible);
+        };
+
+        const showSuccessState = () => {
+            if (storageKey) {
+                storeSuccessTimestamp(storageKey);
+            }
+            clearAllErrors();
+            setFormVisibility(true);
+            setSuccessVisibility(true);
+        };
+
+        const handleStoredSuccess = () => {
+            if (!storageKey) {
+                return;
+            }
+
+            const storedTimestamp = getStoredSuccessTimestamp(storageKey);
+            if (storedTimestamp) {
+                setFormVisibility(true);
+                setSuccessVisibility(true);
+            } else {
+                setSuccessVisibility(successContainer ? successContainer.classList.contains('is-visible') : false);
+                if (successContainer && successContainer.classList.contains('is-visible') && storageKey) {
+                    storeSuccessTimestamp(storageKey);
+                    setFormVisibility(true);
+                } else {
+                    setFormVisibility(false);
+                }
+            }
+        };
+
+        handleStoredSuccess();
+
+        const submitButton = form.querySelector('[type="submit"]');
+        const setSubmittingState = (isSubmitting) => {
+            if (isSubmitting) {
+                form.setAttribute('aria-busy', 'true');
+            } else {
+                form.removeAttribute('aria-busy');
+            }
+
+            if (submitButton) {
+                submitButton.disabled = Boolean(isSubmitting);
+            }
+        };
+
+        const handleFieldEvent = (event) => {
+            const field = event.target;
+            if (!field || !field.name) {
+                return;
+            }
+
+            const message = validateField(field);
+            if (message) {
+                showFieldError(field.name, message);
+                if (storageKey) {
+                    clearStoredSuccess(storageKey);
+                }
+            } else {
+                clearFieldError(field.name);
+                if (!hasActiveFieldErrors()) {
+                    showGlobalErrors([]);
+                }
+            }
+        };
+
+        Array.from(form.elements).forEach((element) => {
+            if (!(element instanceof HTMLElement)) {
+                return;
+            }
+
+            const isInputLike = element.matches('input, textarea, select');
+            if (!isInputLike) {
+                return;
+            }
+
+            element.addEventListener('input', handleFieldEvent);
+            element.addEventListener('change', handleFieldEvent);
+        });
+
+        form.addEventListener('submit', (event) => {
+            event.preventDefault();
+            clearAllErrors();
+
+            const fieldErrors = validateForm();
+            if (Object.keys(fieldErrors).length > 0) {
+                Object.entries(fieldErrors).forEach(([name, message]) => {
+                    showFieldError(name, message);
+                });
+                showGlobalErrors(['Te rugăm să verifici câmpurile marcate.']);
+                return;
+            }
+
+            setSubmittingState(true);
+
+            requestRecaptchaToken()
+                .catch(() => null)
+                .finally(() => {
+                    const formData = new FormData(form);
+
+                    fetch(form.action, {
+                        method: form.method || 'POST',
+                        body: formData,
+                        headers: {
+                            Accept: 'application/json',
+                            'X-Requested-With': 'XMLHttpRequest'
+                        },
+                        credentials: 'same-origin'
+                    })
+                        .then(async (response) => {
+                            let data;
+                            try {
+                                data = await response.json();
+                            } catch (error) {
+                                throw new Error('invalid-response');
+                            }
+
+                            if (!data || typeof data !== 'object') {
+                                throw new Error('invalid-response');
+                            }
+
+                            return data;
+                        })
+                        .then((data) => {
+                            if (data.success) {
+                                showSuccessState();
+                                return;
+                            }
+
+                            const responseFieldErrors = data.fieldErrors || {};
+                            Object.entries(responseFieldErrors).forEach(([name, message]) => {
+                                showFieldError(name, message);
+                            });
+
+                            const responseErrors = Array.isArray(data.errors) ? data.errors : [];
+                            if (responseErrors.length) {
+                                showGlobalErrors(responseErrors);
+                            } else if (Object.keys(responseFieldErrors).length) {
+                                showGlobalErrors(['Te rugăm să verifici câmpurile marcate.']);
+                            } else {
+                                showGlobalErrors(['Nu am putut trimite formularul. Încearcă din nou.']);
+                            }
+
+                            if (storageKey) {
+                                clearStoredSuccess(storageKey);
+                            }
+                        })
+                        .catch(() => {
+                            showGlobalErrors(['Nu am putut trimite formularul. Încearcă din nou sau contactează-ne telefonic.']);
+                        })
+                        .finally(() => {
+                            setSubmittingState(false);
+                        });
+                });
+        });
+    });
 
     const stickyFooterNav = document.querySelector('.mobile-footer-nav');
     if (stickyFooterNav) {

--- a/includes/contact-handler.php
+++ b/includes/contact-handler.php
@@ -8,6 +8,80 @@ function sanitize_input(string $value): string
     return htmlspecialchars($value, ENT_QUOTES, 'UTF-8');
 }
 
+function validate_phone_number(string $phone, bool $isRequired = false): array
+{
+    $phone = trim($phone);
+
+    if ($phone === '') {
+        if ($isRequired) {
+            return [false, 'Numărul de telefon este obligatoriu.'];
+        }
+
+        return [true, ''];
+    }
+
+    $hasPlus = str_starts_with($phone, '+');
+    $digits = $hasPlus ? substr($phone, 1) : $phone;
+
+    if ($digits === '' || preg_match('/\D/', $digits)) {
+        return [false, 'Numărul de telefon poate conține doar cifre (și un singur + la început).'];
+    }
+
+    $length = strlen($digits);
+
+    if ($hasPlus) {
+        if ($length < 6 || $length > 14) {
+            return [false, 'Numărul de telefon în format internațional trebuie să aibă între 6 și 14 cifre.'];
+        }
+    } else {
+        if ($length !== 10) {
+            return [false, 'Numărul de telefon trebuie să conțină exact 10 cifre.'];
+        }
+    }
+
+    return [true, $phone];
+}
+
+function build_submission_metadata(?string $fingerprintRaw = null, ?string $pageUrl = null): string
+{
+    $metadataLines = [];
+    $metadataLines[] = '---- Informații tehnice ----';
+
+    $ipAddress = $_SERVER['REMOTE_ADDR'] ?? 'necunoscut';
+    $userAgent = $_SERVER['HTTP_USER_AGENT'] ?? 'necunoscut';
+    $acceptLanguage = $_SERVER['HTTP_ACCEPT_LANGUAGE'] ?? 'necunoscut';
+    $referer = $_SERVER['HTTP_REFERER'] ?? 'necunoscut';
+    $submittedAt = gmdate('Y-m-d H:i:s') . ' UTC';
+
+    $metadataLines[] = 'IP vizitator: ' . $ipAddress;
+    $metadataLines[] = 'User agent: ' . $userAgent;
+    $metadataLines[] = 'Limbi acceptate: ' . $acceptLanguage;
+    $metadataLines[] = 'Referer: ' . $referer;
+
+    if ($pageUrl) {
+        $metadataLines[] = 'Pagină formular: ' . $pageUrl;
+    }
+
+    $metadataLines[] = 'Moment trimitere: ' . $submittedAt;
+
+    if ($fingerprintRaw) {
+        $decoded = json_decode($fingerprintRaw, true);
+        if (is_array($decoded)) {
+            $metadataLines[] = 'Amprentă dispozitiv:';
+            foreach ($decoded as $key => $value) {
+                if (is_array($value)) {
+                    $value = implode(', ', array_map('strval', $value));
+                }
+                $metadataLines[] = '  - ' . $key . ': ' . (is_scalar($value) ? (string) $value : json_encode($value));
+            }
+        } else {
+            $metadataLines[] = 'Amprentă dispozitiv: ' . $fingerprintRaw;
+        }
+    }
+
+    return "\n\n" . implode("\n", $metadataLines);
+}
+
 function verify_recaptcha(string $token, string $remoteIp): bool
 {
     if (RECAPTCHA_SECRET_KEY === 'YOUR_SECRET_KEY_HERE') {
@@ -32,10 +106,11 @@ function verify_recaptcha(string $token, string $remoteIp): bool
 function handle_contact_form(): array
 {
     $errors = [];
+    $fieldErrors = [];
     $honeypot = $_POST['company'] ?? '';
     if (!empty($honeypot)) {
         $errors[] = 'Formular invalid.';
-        return ['success' => false, 'errors' => $errors];
+        return ['success' => false, 'errors' => $errors, 'fieldErrors' => $fieldErrors];
     }
 
     $name = sanitize_input($_POST['name'] ?? '');
@@ -44,21 +119,32 @@ function handle_contact_form(): array
     $message = sanitize_input($_POST['message'] ?? '');
     $termsAccepted = isset($_POST['terms']) && $_POST['terms'] === '1';
     $token = $_POST['g-recaptcha-response'] ?? '';
+    $fingerprintRaw = isset($_POST['fingerprint']) ? substr((string) $_POST['fingerprint'], 0, 3000) : null;
+    $pageUrl = isset($_POST['page_url']) ? substr((string) $_POST['page_url'], 0, 500) : null;
 
     if ($name === '') {
-        $errors[] = 'Numele este obligatoriu.';
+        $fieldErrors['name'] = 'Numele este obligatoriu.';
     }
 
-    if ($email === '' || !filter_var($email, FILTER_VALIDATE_EMAIL)) {
-        $errors[] = 'Adresa de email nu este validă.';
+    if ($email === '') {
+        $fieldErrors['email'] = 'Adresa de email este obligatorie.';
+    } elseif (!filter_var($email, FILTER_VALIDATE_EMAIL)) {
+        $fieldErrors['email'] = 'Adresa de email nu este validă.';
+    }
+
+    [$isPhoneValid, $normalizedPhone] = validate_phone_number($phone, false);
+    if (!$isPhoneValid) {
+        $fieldErrors['phone'] = $normalizedPhone;
+    } else {
+        $phone = $normalizedPhone;
     }
 
     if ($message === '') {
-        $errors[] = 'Mesajul este obligatoriu.';
+        $fieldErrors['message'] = 'Mesajul este obligatoriu.';
     }
 
     if (!$termsAccepted) {
-        $errors[] = 'Trebuie să accepți Termenii și condițiile și Politica de confidențialitate.';
+        $fieldErrors['terms'] = 'Trebuie să accepți Termenii și condițiile și Politica de confidențialitate.';
     }
 
     if ($token === '') {
@@ -67,12 +153,17 @@ function handle_contact_form(): array
         $errors[] = 'Nu am putut valida reCAPTCHA.';
     }
 
+    if (!empty($fieldErrors)) {
+        $errors = array_merge($errors, array_values($fieldErrors));
+    }
+
     if (!empty($errors)) {
-        return ['success' => false, 'errors' => $errors];
+        return ['success' => false, 'errors' => $errors, 'fieldErrors' => $fieldErrors];
     }
 
     $subject = 'Mesaj nou de pe DesignToro.ro';
     $body = "Nume: {$name}\nEmail: {$email}\nTelefon: {$phone}\nMesaj:\n{$message}";
+    $body .= build_submission_metadata($fingerprintRaw, $pageUrl);
     $headers = 'From: no-reply@designtoro.ro' . "\r\n" . 'Reply-To: ' . $email;
 
     $mailSent = false;
@@ -83,10 +174,11 @@ function handle_contact_form(): array
     if (!$mailSent) {
         return [
             'success' => false,
-            'errors' => ['Momentan nu putem trimite mesajul. Vă rugăm să ne contactați telefonic.']
+            'errors' => ['Momentan nu putem trimite mesajul. Vă rugăm să ne contactați telefonic.'],
+            'fieldErrors' => []
         ];
     }
 
-    return ['success' => true, 'errors' => []];
+    return ['success' => true, 'errors' => [], 'fieldErrors' => []];
 }
 ?>


### PR DESCRIPTION
## Summary
- add asynchronous validation and submission for contact and offer forms, including inline errors, reCAPTCHA refresh, and 24h success gating
- capture device fingerprint details and append technical metadata to notification emails for better context
- refresh form and modal styling, including fade-out close behavior for the offer popup

## Testing
- php -l contact.php
- php -l preturi.php
- php -l includes/contact-handler.php
- php -l includes/offer-handler.php


------
https://chatgpt.com/codex/tasks/task_e_68d71c9cc5a88327bd430e0bef94ab6e