### PR TITLE
Adjust offer modal close button and consent checkbox styles

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -1486,9 +1486,9 @@ video {
 }
 
 .form-group.form-consent {
-    justify-items: center;
-    text-align: center;
-    gap: 0.85rem;
+    justify-items: start;
+    text-align: left;
+    gap: 0.65rem;
     position: relative;
 }
 
@@ -1507,8 +1507,8 @@ video {
 
 .form-consent__label {
     display: flex;
-    flex-direction: column;
-    align-items: center;
+    flex-direction: row;
+    align-items: flex-start;
     gap: 0.75rem;
     cursor: pointer;
     font-weight: 500;
@@ -1518,27 +1518,29 @@ video {
 }
 
 .form-consent__checkbox {
-    width: 4.25rem;
-    height: 4.25rem;
-    border-radius: 1.5rem;
-    border: 1px solid rgba(255, 255, 255, 0.16);
-    background: rgba(229, 9, 20, 0.08);
+    width: 1.65rem;
+    height: 1.65rem;
+    border-radius: 0.5rem;
+    border: 1.5px solid rgba(255, 255, 255, 0.35);
+    background: rgba(8, 8, 13, 0.88);
     display: inline-flex;
     align-items: center;
     justify-content: center;
-    font-size: 2rem;
-    color: rgba(255, 255, 255, 0.55);
-    transition: background 0.3s ease, border-color 0.3s ease, color 0.3s ease, box-shadow 0.3s ease, transform 0.3s ease;
+    font-size: 1rem;
+    color: rgba(255, 255, 255, 0.75);
+    transition: background 0.3s ease, border-color 0.3s ease, color 0.3s ease, box-shadow 0.3s ease, transform 0.2s ease;
 }
 
 .form-consent__checkbox i {
     opacity: 0;
     transform: scale(0.7);
-    transition: opacity 0.25s ease, transform 0.25s ease;
+    transition: opacity 0.2s ease, transform 0.2s ease;
 }
 
 .form-consent__text {
-    max-width: 28rem;
+    max-width: none;
+    display: block;
+    flex: 1;
 }
 
 .form-consent__text a {
@@ -1549,15 +1551,15 @@ video {
 
 .form-consent__input:focus + .form-consent__label .form-consent__checkbox,
 .form-consent__input:focus-visible + .form-consent__label .form-consent__checkbox {
-    box-shadow: 0 0 0 0.25rem rgba(229, 9, 20, 0.3);
+    box-shadow: 0 0 0 0.2rem rgba(229, 9, 20, 0.3);
 }
 
 .form-consent__input:checked + .form-consent__label .form-consent__checkbox {
     background: var(--gradient-accent);
     border-color: transparent;
     color: #fff;
-    box-shadow: 0 20px 45px rgba(229, 9, 20, 0.45);
-    transform: translateY(-2px);
+    box-shadow: 0 12px 25px rgba(229, 9, 20, 0.35);
+    transform: translateY(0);
 }
 
 .form-consent__input:checked + .form-consent__label .form-consent__checkbox i {
@@ -1566,7 +1568,7 @@ video {
 }
 
 .form-group.form-consent .form-error {
-    text-align: center;
+    text-align: left;
 }
 
 .form-shell {
@@ -1660,7 +1662,7 @@ video {
 
 .form-group.has-error .form-consent__checkbox {
     border-color: rgba(229, 9, 20, 0.65);
-    box-shadow: 0 0 0 0.25rem rgba(229, 9, 20, 0.2);
+    box-shadow: 0 0 0 0.2rem rgba(229, 9, 20, 0.2);
 }
 
 .form-group.has-error .form-consent__text {
@@ -1755,6 +1757,10 @@ video {
     justify-content: center;
     cursor: pointer;
     transition: background 0.3s ease, color 0.3s ease, border-color 0.3s ease;
+}
+
+.offer-modal__close > * {
+    pointer-events: none;
 }
 
 .offer-modal__close:hover,


### PR DESCRIPTION
## Summary
- shrink the consent checkbox styling across forms so the agreement line uses a normal-sized check and left-aligned text
- ensure the offer modal close icon remains clickable by disabling pointer events on the decorative icon

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68d78b18ded48327aa02d0f9dbd8c6b8