### PR TITLE
Add WhatsApp CTA to contact success message

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -1592,6 +1592,17 @@ video {
     margin-bottom: 1.5rem;
 }
 
+.form-success-message a {
+    color: #1abc9c;
+    font-weight: 600;
+}
+
+.form-success-message a:hover,
+.form-success-message a:focus {
+    color: #169f83;
+    text-decoration: underline;
+}
+
 .form-success-message.is-visible {
     display: flex;
 }

--- a/contact.php
+++ b/contact.php
@@ -52,7 +52,7 @@ include __DIR__ . '/partials/head.php';
                     </span>
                     <div>
                         <p class="form-success-title">Cererea ta este în curs!</p>
-                        <p>Ți-am primit detaliile și revenim în maximum o zi lucrătoare. Dacă ai completat deja formularul „Cere ofertă”, nu este nevoie să ne trimiți un alt mesaj în următoarele 24 de ore.</p>
+                        <p>Ți-am primit detaliile și revenim în maximum o zi lucrătoare. Ai ceva de adăugat? Contactează-ne pe <a href="https://wa.me/40757568812" class="link-arrow">WhatsApp</a>.</p>
                     </div>
                 </div>
                 <form


### PR DESCRIPTION
## Summary
- refresh the contact form success copy to invite users to follow up on WhatsApp via a direct link
- tweak success message link styling so the call-to-action stands out against the confirmation banner

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d7955b49288327b2ee5824305e64f7