### PR TITLE
Adjust form interactions and success styling

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -1639,21 +1639,24 @@ video {
     gap: 1rem;
     border-radius: 18px;
     padding: 1.25rem 1.5rem;
-    background: rgba(46, 204, 113, 0.12);
-    color: #1d7a46;
-    border: 1px solid rgba(46, 204, 113, 0.35);
+    background: linear-gradient(135deg, rgba(229, 9, 20, 0.18), rgba(178, 7, 16, 0.18));
+    color: var(--color-text);
+    border: 1px solid rgba(229, 9, 20, 0.45);
+    box-shadow: 0 20px 45px rgba(229, 9, 20, 0.15);
     margin-bottom: 1.5rem;
 }
 
 .form-success-message a {
-    color: #1abc9c;
+    color: var(--color-text);
     font-weight: 600;
+    text-decoration: underline;
+    text-decoration-color: rgba(255, 255, 255, 0.35);
 }
 
 .form-success-message a:hover,
 .form-success-message a:focus {
-    color: #169f83;
-    text-decoration: underline;
+    color: #fff;
+    text-decoration-color: #fff;
 }
 
 .form-success-message.is-visible {
@@ -1664,17 +1667,18 @@ video {
     display: inline-flex;
     align-items: center;
     justify-content: center;
-    width: 2.75rem;
-    height: 2.75rem;
+    width: 3rem;
+    height: 3rem;
     border-radius: 999px;
-    background: rgba(46, 204, 113, 0.2);
-    color: #1abc9c;
-    font-size: 1.5rem;
+    background: var(--gradient-accent);
+    color: #fff;
+    font-size: 1.65rem;
+    box-shadow: 0 18px 35px rgba(229, 9, 20, 0.35);
 }
 
 .form-success-title {
-    font-weight: 600;
-    font-size: 1.1rem;
+    font-weight: 700;
+    font-size: 1.15rem;
     margin-bottom: 0.3rem;
 }
 


### PR DESCRIPTION
## Summary
- restyle asynchronous form success notice to match the site's dark accent palette and improve the check icon's visibility
- prevent the offer modal from auto-focusing the name field by redirecting focus to the dialog container
- delay reCAPTCHA badge visibility until a manual challenge or error occurs and show inline validation errors only after a field loses focus

## Testing
- No automated tests were run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68d7a3f4b9c08327ad97f7c7024d14ae