### PR TITLE
Increase z-index of offer modal close button

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -1825,6 +1825,7 @@ video {
     justify-content: center;
     cursor: pointer;
     transition: background 0.3s ease, color 0.3s ease, border-color 0.3s ease;
+    z-index: 10;
 }
 
 .offer-modal__close > * {


### PR DESCRIPTION
## Summary
- ensure the offer modal close button renders above overlapping elements by assigning a higher z-index

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d7bd18bf688327b11987842fd6d3cd