### PR TITLE
Decouple referrer from device fingerprint collection

### DIFF
--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -464,8 +464,7 @@
             hardwareConcurrency: navigator.hardwareConcurrency,
             deviceMemory: navigator.deviceMemory,
             maxTouchPoints: navigator.maxTouchPoints,
-            cookieEnabled: navigator.cookieEnabled,
-            referrer: document.referrer
+            cookieEnabled: navigator.cookieEnabled
         };
 
         let fingerprintString = '';
@@ -477,6 +476,14 @@
 
         fingerprintFields.forEach((field) => {
             field.value = fingerprintString;
+        });
+    }
+
+    const referrerFields = document.querySelectorAll('[data-page-referrer]');
+    if (referrerFields.length) {
+        const referrerValue = document.referrer ? document.referrer.slice(0, 500) : '';
+        referrerFields.forEach((field) => {
+            field.value = referrerValue;
         });
     }
 

--- a/contact.php
+++ b/contact.php
@@ -156,6 +156,7 @@ include __DIR__ . '/partials/head.php';
                     </div>
                     <input type="hidden" name="g-recaptcha-response" data-recaptcha-token>
                     <input type="hidden" name="fingerprint" data-device-fingerprint>
+                    <input type="hidden" name="referrer" data-page-referrer value="<?= htmlspecialchars($_POST['referrer'] ?? '', ENT_QUOTES, 'UTF-8'); ?>">
                     <input type="hidden" name="page_url" value="<?= htmlspecialchars($pageUrl ?? ($_SERVER['REQUEST_URI'] ?? ''), ENT_QUOTES, 'UTF-8'); ?>">
                     <button class="btn btn-accent" type="submit">Trimite mesajul</button>
                 </form>

--- a/includes/offer-handler.php
+++ b/includes/offer-handler.php
@@ -43,7 +43,11 @@ function offer_validate_phone_number(string $phone, bool $isRequired = true): ar
     return [true, $phone];
 }
 
-function offer_build_submission_metadata(?string $fingerprintRaw = null, ?string $pageUrl = null): string
+function offer_build_submission_metadata(
+    ?string $fingerprintRaw = null,
+    ?string $pageUrl = null,
+    ?string $formReferrer = null
+): string
 {
     $metadataLines = [];
     $metadataLines[] = '---- Informații tehnice ----';
@@ -51,7 +55,7 @@ function offer_build_submission_metadata(?string $fingerprintRaw = null, ?string
     $ipAddress = $_SERVER['REMOTE_ADDR'] ?? 'necunoscut';
     $userAgent = $_SERVER['HTTP_USER_AGENT'] ?? 'necunoscut';
     $acceptLanguage = $_SERVER['HTTP_ACCEPT_LANGUAGE'] ?? 'necunoscut';
-    $referer = $_SERVER['HTTP_REFERER'] ?? 'necunoscut';
+    $referer = $formReferrer ?: ($_SERVER['HTTP_REFERER'] ?? 'necunoscut');
     $submittedAt = gmdate('Y-m-d H:i:s') . ' UTC';
 
     $metadataLines[] = 'IP vizitator: ' . $ipAddress;
@@ -125,6 +129,14 @@ function handle_offer_request(): array
     $fingerprintKey = fingerprint_generate_key($fingerprintRaw);
     $fingerprintScopes = ['offer', 'contact'];
     $pageUrl = isset($_POST['page_url']) ? substr((string) $_POST['page_url'], 0, 500) : null;
+    $formReferrer = isset($_POST['referrer']) ? substr((string) $_POST['referrer'], 0, 500) : null;
+    if ($formReferrer !== null) {
+        $sanitizedReferrer = filter_var($formReferrer, FILTER_SANITIZE_URL);
+        $formReferrer = is_string($sanitizedReferrer) ? trim($sanitizedReferrer) : '';
+        if ($formReferrer === '') {
+            $formReferrer = null;
+        }
+    }
 
     if ($fingerprintKey && fingerprint_submission_blocked($fingerprintKey, $fingerprintScopes)) {
         $blockMessage = 'Ai trimis deja un formular în ultimele 24 de ore. Dacă ai detalii suplimentare, contactează-ne pe '
@@ -189,7 +201,7 @@ function handle_offer_request(): array
 
     $bodyLines[] = "Detalii:\n{$details}";
     $body = implode("\n", $bodyLines);
-    $body .= offer_build_submission_metadata($fingerprintRaw, $pageUrl);
+    $body .= offer_build_submission_metadata($fingerprintRaw, $pageUrl, $formReferrer);
     $headers = 'From: no-reply@designtoro.ro' . "\r\n" . 'Reply-To: ' . $email;
 
     $mailSent = false;

--- a/preturi.php
+++ b/preturi.php
@@ -334,6 +334,7 @@ include __DIR__ . '/partials/head.php';
                 <input type="hidden" name="offer_plan" id="offer-plan-field" value="<?= htmlspecialchars($_POST['offer_plan'] ?? '', ENT_QUOTES, 'UTF-8'); ?>">
                 <input type="hidden" name="g-recaptcha-response" data-recaptcha-token>
                 <input type="hidden" name="fingerprint" data-device-fingerprint>
+                <input type="hidden" name="referrer" data-page-referrer value="<?= htmlspecialchars($_POST['referrer'] ?? '', ENT_QUOTES, 'UTF-8'); ?>">
                 <input type="hidden" name="page_url" value="<?= htmlspecialchars($pageUrl ?? ($_SERVER['REQUEST_URI'] ?? ''), ENT_QUOTES, 'UTF-8'); ?>">
                 <button class="btn btn-accent" type="submit" data-offer-animate>Trimite cererea</button>
             </form>


### PR DESCRIPTION
## Summary
- remove referrer and other volatile data from the client fingerprint payload
- capture the document referrer in dedicated hidden fields so it can be processed separately
- pass sanitized referrer data to submission metadata without impacting fingerprint throttling

## Testing
- php -l contact.php
- php -l preturi.php
- php -l includes/contact-handler.php
- php -l includes/offer-handler.php

------
https://chatgpt.com/codex/tasks/task_e_68d82adac8a883279ba8f20cc1afc6b5