### PR TITLE
Adjust offer modal timings and spacing

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -1803,7 +1803,7 @@ video {
 }
 
 .offer-modal.is-closing .offer-modal__backdrop {
-    animation: offerModalOutBackdrop 0.28s ease forwards;
+    animation: offerModalOutBackdrop 0.35s ease forwards;
 }
 
 .offer-modal.is-closing .offer-modal__dialog {
@@ -1851,7 +1851,7 @@ video {
 
 .offer-form {
     display: grid;
-    gap: 1.1rem;
+    gap: clamp(0.75rem, 1.8vw, 1rem);
 }
 
 .offer-form .form-group {

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -303,7 +303,7 @@
         const prefersReducedMotion = typeof window.matchMedia === 'function'
             ? window.matchMedia('(prefers-reduced-motion: reduce)')
             : { matches: false };
-        const offerModalCloseDuration = prefersReducedMotion.matches ? 0 : 280;
+        const offerModalCloseDuration = prefersReducedMotion.matches ? 0 : 350;
 
         if (offerDialog && !offerDialog.hasAttribute('tabindex')) {
             offerDialog.setAttribute('tabindex', '-1');
@@ -321,8 +321,8 @@
 
             window.requestAnimationFrame(() => {
                 animatedElements.forEach((element, index) => {
-                    const delayBase = prefersReducedMotion.matches ? 0 : 250;
-                    const delayStep = prefersReducedMotion.matches ? 0 : 180;
+                    const delayBase = prefersReducedMotion.matches ? 0 : 180;
+                    const delayStep = prefersReducedMotion.matches ? 0 : 120;
                     const delay = delayBase + (delayStep * index);
 
                     if (delay) {


### PR DESCRIPTION
## Summary
- align the offer modal close animation duration with the JS timeout to keep the fade-out in sync
- speed up the sequential field animation so inputs appear fluidly with their labels
- tighten the offer form grid gap for a more cohesive layout

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68d85f3e02b88327b1074733fb5682ba