### PR TITLE
Update FAQ timeline estimate

### DIFF
--- a/index.php
+++ b/index.php
@@ -262,8 +262,8 @@ include __DIR__ . '/partials/head.php';
         <div class="faq-grid">
             <article class="faq-item">
                 <h3>Cât durează să lansăm un site?</h3>
-                <p>În mod obișnuit, un site complet durează între 6 și 10 săptămâni, în funcție de numărul de pagini și materiale.
-                Îți arătăm stadiul proiectului în fiecare săptămână.</p>
+                <p>În mod obișnuit, un site complet durează între 1 și 6 săptămâni, în funcție de complexitate și materialele
+                pe care le avem disponibile. Îți arătăm stadiul proiectului în fiecare săptămână.</p>
             </article>
             <article class="faq-item">
                 <h3>Ce include pachetul de SEO și conținut?</h3>


### PR DESCRIPTION
## Summary
- update the FAQ answer about project duration to state that sites take between 1 and 6 weeks depending on complexity
- clarify that availability of materials can influence the delivery timeline and reaffirm weekly progress updates

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68da55a0eb9883278fe3466c097a8d14