### PR TITLE
Enable hero gradient on mobile

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -273,11 +273,16 @@ video {
     position: relative;
     padding: clamp(6rem, 8vw, 8rem) 0 5rem;
     overflow: hidden;
-    /* background:
+    background:
         radial-gradient(circle at 15% 20%, rgba(229, 9, 20, 0.45), transparent 62%),
         radial-gradient(circle at 85% 5%, rgba(118, 17, 23, 0.35), transparent 55%),
-        linear-gradient(160deg, #050505 0%, #0d0d11 65%, #050505 100%); */
-    background: url('/img/designtoro-hero.webp') center/cover no-repeat;
+        linear-gradient(160deg, #050505 0%, #0d0d11 65%, #050505 100%);
+}
+
+@media (min-width: 992px) {
+    .hero {
+        background: url('/img/designtoro-hero.webp') center/cover no-repeat;
+    }
 }
 
 .hero::after {


### PR DESCRIPTION
## Summary
- restore the gradient background for the hero section as the default mobile styling
- ensure desktop viewports continue using the existing WebP hero background via a media query override

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68dbd6ee281883269c40be328fd1d201