### PR TITLE
Make home header gradient transparent on load

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -148,6 +148,18 @@ video {
     transition: background 0.3s ease, backdrop-filter 0.3s ease, border-color 0.3s ease;
 }
 
+.page-home .site-header {
+    background: linear-gradient(180deg, rgba(8, 8, 14, 0.8) 0%, rgba(8, 8, 14, 0.45) 70%, rgba(8, 8, 14, 0) 100%);
+    border-bottom: 1px solid rgba(255, 255, 255, 0.08);
+    backdrop-filter: none;
+}
+
+.page-home .site-header.is-sticky {
+    background: rgba(8, 8, 14, 0.78);
+    border-bottom: 1px solid rgba(255, 255, 255, 0.12);
+    backdrop-filter: blur(18px);
+}
+
 .site-header.is-sticky {
     background: rgba(8, 8, 14, 0.78);
     border-bottom: 1px solid rgba(255, 255, 255, 0.12);

--- a/index.php
+++ b/index.php
@@ -5,6 +5,7 @@ $pageDescription = 'DesignToro creează site-uri clare și campanii ușor de în
 $pageKeywords = 'agenție web design, creare site bucurești, marketing digital, servicii seo, promovare online';
 $pageUrl = 'https://www.designtoro.ro/';
 $currentPage = 'home';
+$bodyClasses[] = 'page-home';
 
 $experienceStartDate = new DateTime('2013-10-13');
 $experienceYears = max(1, $experienceStartDate->diff(new DateTime())->y);


### PR DESCRIPTION
## Summary
- add a dedicated body class for the homepage template
- style the homepage header with a transparent-to-black gradient until it becomes sticky

## Testing
- not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68dd0d6ab904832691ab04615faee54d