### PR TITLE
Make homepage header transparent overlay

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -142,22 +142,49 @@ video {
 }
 
 .site-header {
+    position: relative;
     border-bottom: 1px solid var(--color-border);
-    background: #ff00002b;
+    background: rgba(8, 8, 14, 0.75);
     backdrop-filter: none;
     transition: background 0.3s ease, backdrop-filter 0.3s ease, border-color 0.3s ease;
 }
 
 .page-home .site-header {
-    background: linear-gradient(180deg, rgba(8, 8, 14, 0.8) 0%, rgba(8, 8, 14, 0.45) 70%, rgba(8, 8, 14, 0) 100%);
-    border-bottom: 1px solid rgba(255, 255, 255, 0.08);
-    backdrop-filter: none;
+    position: absolute;
+    top: 0;
+    left: 0;
+    right: 0;
+    border-bottom-color: transparent;
+    background: transparent;
+    z-index: 1000;
+}
+
+.page-home .site-header::before {
+    content: '';
+    position: absolute;
+    inset: 0;
+    background: linear-gradient(180deg, rgba(5, 5, 8, 0.85) 0%, rgba(5, 5, 8, 0.45) 60%, rgba(5, 5, 8, 0) 100%);
+    pointer-events: none;
+    transition: opacity 0.3s ease;
+}
+
+.page-home .site-header .navbar {
+    position: relative;
+    z-index: 1;
 }
 
 .page-home .site-header.is-sticky {
+    position: fixed;
+    top: 0;
+    left: 0;
+    right: 0;
     background: rgba(8, 8, 14, 0.78);
     border-bottom: 1px solid rgba(255, 255, 255, 0.12);
     backdrop-filter: blur(18px);
+}
+
+.page-home .site-header.is-sticky::before {
+    opacity: 0;
 }
 
 .site-header.is-sticky {
@@ -289,6 +316,10 @@ video {
         radial-gradient(circle at 15% 20%, rgba(229, 9, 20, 0.45), transparent 62%),
         radial-gradient(circle at 85% 5%, rgba(118, 17, 23, 0.35), transparent 55%),
         linear-gradient(160deg, #050505 0%, #0d0d11 65%, #050505 100%);
+}
+
+.page-home .hero {
+    padding-top: clamp(8rem, 12vw, 10rem);
 }
 
 @media (min-width: 992px) {


### PR DESCRIPTION
## Summary
- make the homepage header transparent with a dark gradient overlay that fades out like Netflix
- keep the sticky state solid and blur while ensuring navigation content stays above the overlay
- increase the hero section top padding so content is not hidden under the overlaid header

## Testing
- Manual QA: Viewed the homepage header locally

------
https://chatgpt.com/codex/tasks/task_e_68de8d70f86c832fa98ec064a98e6680