### PR TITLE
Add asset versioning for stylesheet cache busting

### DIFF
--- a/config/app.php
+++ b/config/app.php
@@ -1,0 +1,4 @@
+<?php
+return [
+    'asset_version' => '1.0.0',
+];

--- a/partials/head.php
+++ b/partials/head.php
@@ -12,6 +12,13 @@ if (!isset($pageUrl)) {
     $pageUrl = 'https://www.designtoro.ro/';
 }
 require_once __DIR__ . '/../config/sitekey.php';
+$config = require __DIR__ . '/../config/app.php';
+if (!is_array($config)) {
+    $config = [];
+}
+$assetVersion = isset($config['asset_version'])
+    ? htmlspecialchars((string) $config['asset_version'], ENT_QUOTES, 'UTF-8')
+    : '1.0.0';
 $bodyClasses = $bodyClasses ?? [];
 if (!is_array($bodyClasses)) {
     $bodyClasses = [$bodyClasses];
@@ -45,7 +52,7 @@ $bodyClassAttribute = htmlspecialchars(implode(' ', array_unique($bodyClasses)),
         integrity="sha384-PPIZEGYM1v8zp5Py7UjFb79S58UeqCL9pYVnVPURKEqvioPROaVAJKKLzvH2rDnI"
         crossorigin="anonymous"
     >
-    <link rel="stylesheet" href="/assets/css/style.css">
+    <link rel="stylesheet" href="/assets/css/style.css?v=<?= $assetVersion; ?>">
     <script>
         window.RECAPTCHA_SITE_KEY = '<?= RECAPTCHA_SITE_KEY; ?>';
     </script>


### PR DESCRIPTION
## Summary
- introduce a central app configuration file with an asset version string
- load the asset version in the head partial and append it as a query parameter to the stylesheet link

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68de9015df18832f92643bbde0b8c4e0