### PR TITLE
Adjust hero section spacing on home page

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -312,6 +312,7 @@ video {
     position: relative;
     padding: clamp(6rem, 8vw, 8rem) 0 5rem;
     overflow: hidden;
+    margin-top: 90px;
     background:
         radial-gradient(circle at 15% 20%, rgba(229, 9, 20, 0.45), transparent 62%),
         radial-gradient(circle at 85% 5%, rgba(118, 17, 23, 0.35), transparent 55%),
@@ -325,6 +326,7 @@ video {
 @media (min-width: 992px) {
     .hero {
         background: url('/img/designtoro-hero.webp') center/cover no-repeat;
+        margin-top: 180px;
     }
 }
 


### PR DESCRIPTION
## Summary
- add a default top margin to the hero section
- increase the hero top margin on desktop viewports for additional spacing

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68de9168d00c832f9d455e174269221e