### PR TITLE
Make home header transparent with hero overlay

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -146,7 +146,8 @@ video {
     border-bottom: 1px solid var(--color-border);
     background: rgba(8, 8, 14, 0.75);
     backdrop-filter: none;
-    transition: background 0.3s ease, backdrop-filter 0.3s ease, border-color 0.3s ease;
+    transition: background 0.3s ease, backdrop-filter 0.3s ease, border-color 0.3s ease,
+        box-shadow 0.3s ease;
 }
 
 .page-home .site-header {
@@ -156,6 +157,7 @@ video {
     right: 0;
     border-bottom-color: transparent;
     background: transparent;
+    box-shadow: none;
     z-index: 1000;
 }
 
@@ -163,7 +165,7 @@ video {
     content: '';
     position: absolute;
     inset: 0;
-    background: linear-gradient(180deg, rgba(5, 5, 8, 0.85) 0%, rgba(5, 5, 8, 0.45) 60%, rgba(5, 5, 8, 0) 100%);
+    background: linear-gradient(180deg, rgba(5, 5, 8, 0.82) 0%, rgba(5, 5, 8, 0.5) 52%, rgba(5, 5, 8, 0.22) 78%, rgba(5, 5, 8, 0) 100%);
     pointer-events: none;
     transition: opacity 0.3s ease;
 }
@@ -312,7 +314,7 @@ video {
     position: relative;
     padding: clamp(6rem, 8vw, 8rem) 0 5rem;
     overflow: hidden;
-    margin-top: 90px;
+    margin-top: 0;
     background:
         radial-gradient(circle at 15% 20%, rgba(229, 9, 20, 0.45), transparent 62%),
         radial-gradient(circle at 85% 5%, rgba(118, 17, 23, 0.35), transparent 55%),


### PR DESCRIPTION
## Summary
- adjust the home page header to stay transparent with a subtle dark gradient overlay
- remove the hero section offset so the background imagery extends beneath the transparent header

## Testing
- not run (CSS-only change)


------
https://chatgpt.com/codex/tasks/task_e_68de92bc2adc832fa68106bf9bf527e4