### PR TITLE
Adjust hero spacing on home page

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -322,12 +322,16 @@ video {
 }
 
 .page-home .hero {
-    padding-top: clamp(8rem, 12vw, 10rem);
+    padding-top: 90px;
 }
 
 @media (min-width: 992px) {
     .hero {
         background: url('/img/designtoro-hero.webp') center/cover no-repeat;
+        padding-top: 180px;
+    }
+
+    .page-home .hero {
         padding-top: 180px;
     }
 }


### PR DESCRIPTION
## Summary
- ensure the home page hero has 90px top spacing on smaller screens so the text clears the header gradient
- keep a dedicated 180px top padding for the home hero on desktop widths

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68de941911fc832fa8abdc1113d4e449