### PR TITLE
Adjust hero text padding responsiveness

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -351,6 +351,16 @@ video {
     z-index: 1;
 }
 
+.col-12.col-lg-10.col-xl-8.hero-text {
+    padding-top: 90px;
+}
+
+@media (min-width: 992px) {
+    .col-12.col-lg-10.col-xl-8.hero-text {
+        padding-top: 180px;
+    }
+}
+
 .hero-text h1 {
     font-size: clamp(2.9rem, 6vw, 4.5rem);
     line-height: 1.04;


### PR DESCRIPTION
## Summary
- set the hero text column to use 90px padding on mobile and 180px on desktop for consistent spacing

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68de952c956c832fa8d4964230651868