### PR TITLE
Build dynamic portfolio gallery

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -1463,17 +1463,77 @@ video {
     border-radius: 24px;
     overflow: hidden;
     background: rgba(20, 20, 26, 0.92);
-    min-height: 220px;
-    display: flex;
-    flex-direction: column;
-    justify-content: space-between;
     border: 1px solid rgba(255, 255, 255, 0.05);
     box-shadow: var(--shadow-soft);
+    transition: transform 0.3s ease, box-shadow 0.3s ease;
+    height: 100%;
+}
+
+.portfolio-item:hover,
+.portfolio-item:focus-within {
+    transform: translateY(-4px);
+    box-shadow: 0 32px 55px rgba(0, 0, 0, 0.55);
+}
+
+.portfolio-link {
+    display: flex;
+    flex-direction: column;
+    height: 100%;
+    color: inherit;
+    text-decoration: none;
+}
+
+.portfolio-link:focus {
+    outline: none;
+}
+
+.portfolio-link:focus-visible {
+    outline: 2px solid var(--color-accent);
+    outline-offset: 4px;
+}
+
+figure.portfolio-media {
+    margin: 0;
+    aspect-ratio: 960 / 1890;
+    overflow: hidden;
+    background: rgba(12, 12, 18, 0.9);
+    border-bottom: 1px solid rgba(255, 255, 255, 0.05);
+}
+
+figure.portfolio-media img {
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+    display: block;
 }
 
 .portfolio-details {
     padding: 1.5rem;
     color: rgba(255, 255, 255, 0.85);
+    display: flex;
+    flex-direction: column;
+    gap: 0.35rem;
+}
+
+.portfolio-details h2 {
+    margin: 0;
+    font-size: 1.1rem;
+    color: #fff;
+}
+
+.portfolio-details p {
+    margin: 0;
+    color: rgba(255, 255, 255, 0.65);
+    font-size: 0.95rem;
+}
+
+.portfolio-empty {
+    color: rgba(255, 255, 255, 0.7);
+    text-align: center;
+    padding: 3rem 1rem;
+    border-radius: 20px;
+    background: rgba(15, 15, 22, 0.85);
+    border: 1px dashed rgba(255, 255, 255, 0.08);
 }
 
 .contact-hero {

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -79,7 +79,7 @@
                 const category = item.getAttribute('data-category');
                 const isVisible = filter === 'all' || category === filter;
                 item.setAttribute('aria-hidden', String(!isVisible));
-                item.style.display = isVisible ? 'flex' : 'none';
+                item.style.display = isVisible ? '' : 'none';
             });
         });
     });

--- a/portofoliu.php
+++ b/portofoliu.php
@@ -1,10 +1,102 @@
 <?php
 require_once __DIR__ . '/includes/security-headers.php';
+
 $pageTitle = 'Portofoliu Web Design și Proiecte Digitale | DesignToro';
 $pageDescription = 'Explorează proiectele DesignToro: site-uri, magazine online și materiale de brand create pentru clienți din diferite domenii.';
 $pageKeywords = 'portofoliu web design, proiecte site-uri, exemple magazine online, lucrări design';
 $pageUrl = 'https://www.designtoro.ro/portofoliu';
 $currentPage = 'portofoliu';
+
+$portfolioPath = __DIR__ . '/img/portofoliu';
+$portfolioItems = [];
+
+$typeMap = [
+    'prezentare' => [
+        'category' => 'website',
+        'label' => 'Site de prezentare',
+        'alt' => 'Previzualizare site de prezentare %s',
+    ],
+    'magazin' => [
+        'category' => 'ecommerce',
+        'label' => 'Magazin online',
+        'alt' => 'Previzualizare magazin online %s',
+    ],
+    'branding' => [
+        'category' => 'branding',
+        'label' => 'Identitate și conținut',
+        'alt' => 'Previzualizare proiect de branding %s',
+    ],
+];
+
+if (is_dir($portfolioPath)) {
+    $files = glob($portfolioPath . '/*.webp');
+    sort($files, SORT_NATURAL | SORT_FLAG_CASE);
+
+    foreach ($files as $file) {
+        $filename = basename($file);
+
+        if (!preg_match('/^(.+?)_(prezentare|magazin|branding)\.webp$/', $filename, $matches)) {
+            continue;
+        }
+
+        $domain = $matches[1];
+        $typeKey = $matches[2];
+
+        if (!isset($typeMap[$typeKey])) {
+            continue;
+        }
+
+        $url = 'https://' . $domain;
+        $host = parse_url($url, PHP_URL_HOST) ?: $domain;
+        $primaryLabel = explode('.', $host)[0];
+        $readableName = str_replace(['-', '_'], ' ', $primaryLabel);
+
+        if (function_exists('mb_convert_case')) {
+            $readableName = mb_convert_case($readableName, MB_CASE_TITLE, 'UTF-8');
+        } else {
+            $readableName = ucwords($readableName);
+        }
+
+        $portfolioItems[] = [
+            'filename' => $filename,
+            'url' => $url,
+            'host' => $host,
+            'name' => $readableName,
+            'category' => $typeMap[$typeKey]['category'],
+            'label' => $typeMap[$typeKey]['label'],
+            'alt' => sprintf($typeMap[$typeKey]['alt'], $readableName),
+        ];
+    }
+}
+
+usort(
+    $portfolioItems,
+    static function (array $first, array $second): int {
+        return strcmp($first['name'], $second['name']);
+    }
+);
+
+$filters = [
+    'all' => [
+        'label' => 'Toate',
+        'always' => true,
+    ],
+    'website' => [
+        'label' => 'Site-uri de prezentare',
+    ],
+    'ecommerce' => [
+        'label' => 'Magazine online',
+    ],
+    'branding' => [
+        'label' => 'Identitate și conținut',
+    ],
+];
+
+$availableCategories = [];
+foreach ($portfolioItems as $item) {
+    $availableCategories[$item['category']] = true;
+}
+
 include __DIR__ . '/partials/head.php';
 ?>
 <section class="page-hero py-5" aria-labelledby="portfolio-hero">
@@ -15,80 +107,50 @@ include __DIR__ . '/partials/head.php';
 </section>
 <section class="portfolio-filters py-3" aria-label="Filtre portofoliu">
     <div class="container filter-buttons">
-        <button class="filter-button is-active" data-filter="all">Toate</button>
-        <button class="filter-button" data-filter="website">Site-uri de prezentare</button>
-        <button class="filter-button" data-filter="ecommerce">Magazine online</button>
-        <button class="filter-button" data-filter="branding">Identitate și conținut</button>
+        <?php foreach ($filters as $filterKey => $filter): ?>
+            <?php if (!($filter['always'] ?? false) && !isset($availableCategories[$filterKey])): ?>
+                <?php continue; ?>
+            <?php endif; ?>
+            <button
+                class="filter-button<?= $filterKey === 'all' ? ' is-active' : '' ?>"
+                data-filter="<?= htmlspecialchars($filterKey, ENT_QUOTES) ?>"
+            >
+                <?= htmlspecialchars($filter['label'], ENT_QUOTES) ?>
+            </button>
+        <?php endforeach; ?>
     </div>
 </section>
 <section class="portfolio-gallery py-4" aria-label="Galerie portofoliu">
     <div class="container portfolio-masonry">
-        <article class="portfolio-item" data-category="website">
-            <div class="portfolio-media">
-                <div class="mockup-card mockup-pulse" role="img" aria-label="Previzualizare proiect Pulse Media">
-                    <span class="mockup-label" aria-hidden="true">Pulse Media</span>
-                </div>
-            </div>
-            <div class="portfolio-details">
-                <h2>Pulse Media</h2>
-                <p>Site de știri și newsletter ușor de administrat</p>
-            </div>
-        </article>
-        <article class="portfolio-item" data-category="ecommerce">
-            <div class="portfolio-media">
-                <div class="mockup-card mockup-nebula" role="img" aria-label="Previzualizare proiect Nebula Commerce">
-                    <span class="mockup-label" aria-hidden="true">Nebula Commerce</span>
-                </div>
-            </div>
-            <div class="portfolio-details">
-                <h2>Nebula Commerce</h2>
-                <p>Magazin online de modă cu experiență simplă de cumpărare</p>
-            </div>
-        </article>
-        <article class="portfolio-item" data-category="branding">
-            <div class="portfolio-media">
-                <div class="mockup-card mockup-skyline" role="img" aria-label="Previzualizare proiect Skyline Air">
-                    <span class="mockup-label" aria-hidden="true">Skyline Air</span>
-                </div>
-            </div>
-            <div class="portfolio-details">
-                <h2>Skyline Air</h2>
-                <p>Identitate vizuală și platformă clară de rezervări</p>
-            </div>
-        </article>
-        <article class="portfolio-item" data-category="website">
-            <div class="portfolio-media">
-                <div class="mockup-card mockup-prime" role="img" aria-label="Previzualizare proiect Prime Estates">
-                    <span class="mockup-label" aria-hidden="true">Prime Estates</span>
-                </div>
-            </div>
-            <div class="portfolio-details">
-                <h2>Prime Estates</h2>
-                <p>Site imobiliar cu tururi virtuale și formulare clare</p>
-            </div>
-        </article>
-        <article class="portfolio-item" data-category="ecommerce">
-            <div class="portfolio-media">
-                <div class="mockup-card mockup-orbit" role="img" aria-label="Previzualizare proiect Orbit Tech">
-                    <span class="mockup-label" aria-hidden="true">Orbit Tech</span>
-                </div>
-            </div>
-            <div class="portfolio-details">
-                <h2>Orbit Tech</h2>
-                <p>Magazin B2B cu comenzi rapide și integrare ERP</p>
-            </div>
-        </article>
-        <article class="portfolio-item" data-category="branding">
-            <div class="portfolio-media">
-                <div class="mockup-card mockup-lumen" role="img" aria-label="Previzualizare proiect Lumen Studio">
-                    <span class="mockup-label" aria-hidden="true">Lumen Studio</span>
-                </div>
-            </div>
-            <div class="portfolio-details">
-                <h2>Lumen Studio</h2>
-                <p>Manual de brand și materiale ușor de folosit</p>
-            </div>
-        </article>
+        <?php if (!empty($portfolioItems)): ?>
+            <?php foreach ($portfolioItems as $item): ?>
+                <article class="portfolio-item" data-category="<?= htmlspecialchars($item['category'], ENT_QUOTES) ?>">
+                    <a
+                        class="portfolio-link"
+                        href="<?= htmlspecialchars($item['url'], ENT_QUOTES) ?>"
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        aria-label="Deschide <?= htmlspecialchars($item['host'], ENT_QUOTES) ?>"
+                    >
+                        <figure class="portfolio-media">
+                            <img
+                                src="/img/portofoliu/<?= htmlspecialchars($item['filename'], ENT_QUOTES) ?>"
+                                alt="<?= htmlspecialchars($item['alt'], ENT_QUOTES) ?>"
+                                loading="lazy"
+                                width="960"
+                                height="1890"
+                            >
+                        </figure>
+                        <div class="portfolio-details">
+                            <h2><?= htmlspecialchars($item['name'], ENT_QUOTES) ?></h2>
+                            <p><?= htmlspecialchars($item['label'], ENT_QUOTES) ?></p>
+                        </div>
+                    </a>
+                </article>
+            <?php endforeach; ?>
+        <?php else: ?>
+            <p class="portfolio-empty">Momentan pregătim proiectele pentru această secțiune. Revino curând pentru noutăți.</p>
+        <?php endif; ?>
     </div>
 </section>
 <section class="cta-banner py-5" aria-labelledby="cta-portfolio">


### PR DESCRIPTION
## Summary
- generate portfolio entries on the portfolio page from the `/img/portofoliu` directory
- refresh gallery card styling to display the new screenshots while maintaining their aspect ratio
- adjust the filter script to preserve default layout styles when toggling categories

## Testing
- php -l portofoliu.php

------
https://chatgpt.com/codex/tasks/task_e_68dea0ab2510832fbc56a20ed8c8209c