### PR TITLE
Reveal initial portfolio items after load

### DIFF
--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -69,6 +69,20 @@
     const filterButtons = document.querySelectorAll('.filter-button');
     const portfolioItems = document.querySelectorAll('.portfolio-item');
 
+    if (portfolioItems.length > 0) {
+        const earlyRevealCount = Math.min(portfolioItems.length, 4);
+        const earlyRevealDelay = 200;
+
+        window.setTimeout(() => {
+            portfolioItems.forEach((item, index) => {
+                if (index < earlyRevealCount && item.classList.contains('reveal')) {
+                    item.classList.add('in-view');
+                    observer.unobserve(item);
+                }
+            });
+        }, earlyRevealDelay);
+    }
+
     filterButtons.forEach((button) => {
         button.addEventListener('click', () => {
             const filter = button.getAttribute('data-filter');


### PR DESCRIPTION
## Summary
- add a short timeout to reveal the first few portfolio slots right after page load
- stop observing the preloaded portfolio items once they are shown

## Testing
- no automated tests were run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68deef100390832fb9cf30a00db766b7