### PR TITLE
Update homepage portfolio section with live projects

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -916,6 +916,17 @@ video {
     grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
 }
 
+.portfolio-card-link {
+    position: relative;
+    display: flex;
+    flex-direction: column;
+    height: 100%;
+    color: inherit;
+    text-decoration: none;
+    border-radius: inherit;
+    overflow: hidden;
+}
+
 .portfolio-card {
     position: relative;
     border-radius: 24px;
@@ -935,6 +946,34 @@ video {
     background:
         radial-gradient(circle at 20% 20%, rgba(229, 9, 20, 0.18), transparent 60%),
         rgba(12, 12, 18, 0.85);
+}
+
+.portfolio-card .portfolio-media {
+    display: block;
+    padding: 0;
+    overflow: hidden;
+    border-radius: 20px;
+    background: none;
+}
+
+.portfolio-card .portfolio-media img {
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+    display: block;
+}
+
+.portfolio-card .portfolio-media::after {
+    content: '';
+    position: absolute;
+    inset: 0;
+    background: linear-gradient(180deg, rgba(5, 5, 10, 0.1), rgba(5, 5, 10, 0.35));
+    transition: opacity 0.3s ease;
+}
+
+.portfolio-card:hover .portfolio-media::after,
+.portfolio-card:focus-within .portfolio-media::after {
+    opacity: 0;
 }
 
 .mockup-card {
@@ -1073,6 +1112,20 @@ video {
 .portfolio-card:hover .portfolio-overlay,
 .portfolio-card:focus-within .portfolio-overlay {
     opacity: 1;
+}
+
+.portfolio-category {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    padding: 0.35rem 0.9rem;
+    border-radius: 999px;
+    background: rgba(255, 255, 255, 0.12);
+    color: rgba(255, 255, 255, 0.85);
+    font-size: 0.75rem;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    margin-bottom: 0.75rem;
 }
 
 .portfolio-item .portfolio-media,

--- a/index.php
+++ b/index.php
@@ -10,6 +10,41 @@ $bodyClasses[] = 'page-home';
 $experienceStartDate = new DateTime('2013-10-13');
 $experienceYears = max(1, $experienceStartDate->diff(new DateTime())->y);
 
+$recentProjects = [
+    [
+        'name' => 'Kinetofusion',
+        'url' => 'https://kinetofusion.ro',
+        'image' => '/img/portofoliu/kinetofusion.ro_prezentare.webp',
+        'alt' => 'Previzualizare site de prezentare Kinetofusion',
+        'type' => 'Site de prezentare',
+        'description' => 'Platformă clară pentru programări și servicii de kinetoterapie.',
+    ],
+    [
+        'name' => 'Sf. Vasile',
+        'url' => 'https://sfvasile.ro',
+        'image' => '/img/portofoliu/sfvasile.ro_prezentare.webp',
+        'alt' => 'Previzualizare site de prezentare Sf. Vasile',
+        'type' => 'Site de prezentare',
+        'description' => 'Calendar, anunțuri și informații actualizate pentru comunitate.',
+    ],
+    [
+        'name' => 'ExpertConfort',
+        'url' => 'https://expertconfort.ro',
+        'image' => '/img/portofoliu/expertconfort.ro_prezentare.webp',
+        'alt' => 'Previzualizare site de prezentare ExpertConfort',
+        'type' => 'Site de prezentare',
+        'description' => 'Prezentare a serviciilor HVAC și a soluțiilor de mentenanță.',
+    ],
+    [
+        'name' => 'FixiShop',
+        'url' => 'https://fixishop.ro',
+        'image' => '/img/portofoliu/fixishop.ro_magazin.webp',
+        'alt' => 'Previzualizare magazin online FixiShop',
+        'type' => 'Magazin online',
+        'description' => 'Catalog de accesorii și consumabile pentru reparații rapide.',
+    ],
+];
+
 include __DIR__ . '/partials/head.php';
 ?>
 <section class="hero py-5" aria-labelledby="hero-title">
@@ -153,50 +188,32 @@ include __DIR__ . '/partials/head.php';
             <a class="link-arrow" href="/portofoliu">Vezi toate exemplele</a>
         </div>
         <div class="portfolio-grid">
-            <article class="portfolio-card">
-                <div class="portfolio-media">
-                    <div class="mockup-card mockup-pulse" role="img" aria-label="Previzualizare proiect Pulse Media">
-                        <span class="mockup-label" aria-hidden="true">Pulse Media</span>
-                    </div>
-                </div>
-                <div class="portfolio-overlay">
-                    <h3>Pulse Media</h3>
-                    <p>Site de știri și newsletter ușor de actualizat</p>
-                </div>
-            </article>
-            <article class="portfolio-card">
-                <div class="portfolio-media">
-                    <div class="mockup-card mockup-nebula" role="img" aria-label="Previzualizare proiect Nebula Commerce">
-                        <span class="mockup-label" aria-hidden="true">Nebula Commerce</span>
-                    </div>
-                </div>
-                <div class="portfolio-overlay">
-                    <h3>Nebula Commerce</h3>
-                    <p>Magazin online de modă cu proces de cumpărare simplu</p>
-                </div>
-            </article>
-            <article class="portfolio-card">
-                <div class="portfolio-media">
-                    <div class="mockup-card mockup-skyline" role="img" aria-label="Previzualizare proiect Skyline Air">
-                        <span class="mockup-label" aria-hidden="true">Skyline Air</span>
-                    </div>
-                </div>
-                <div class="portfolio-overlay">
-                    <h3>Skyline Air</h3>
-                    <p>Platformă de rezervări cu explicații pas cu pas</p>
-                </div>
-            </article>
-            <article class="portfolio-card">
-                <div class="portfolio-media">
-                    <div class="mockup-card mockup-prime" role="img" aria-label="Previzualizare proiect Prime Estates">
-                        <span class="mockup-label" aria-hidden="true">Prime Estates</span>
-                    </div>
-                </div>
-                <div class="portfolio-overlay">
-                    <h3>Prime Estates</h3>
-                    <p>Site imobiliar cu tururi virtuale și formulare clare</p>
-                </div>
-            </article>
+            <?php foreach ($recentProjects as $project): ?>
+                <article class="portfolio-card">
+                    <a
+                        class="portfolio-card-link"
+                        href="<?= htmlspecialchars($project['url'], ENT_QUOTES) ?>"
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        aria-label="Deschide <?= htmlspecialchars($project['name'], ENT_QUOTES) ?>"
+                    >
+                        <figure class="portfolio-media">
+                            <img
+                                src="<?= htmlspecialchars($project['image'], ENT_QUOTES) ?>"
+                                alt="<?= htmlspecialchars($project['alt'], ENT_QUOTES) ?>"
+                                loading="lazy"
+                                width="960"
+                                height="1890"
+                            >
+                        </figure>
+                        <div class="portfolio-overlay">
+                            <span class="portfolio-category"><?= htmlspecialchars($project['type'], ENT_QUOTES) ?></span>
+                            <h3><?= htmlspecialchars($project['name'], ENT_QUOTES) ?></h3>
+                            <p><?= htmlspecialchars($project['description'], ENT_QUOTES) ?></p>
+                        </div>
+                    </a>
+                </article>
+            <?php endforeach; ?>
         </div>
     </div>
 </section>


### PR DESCRIPTION
## Summary
- populate the homepage "Proiecte recente" section from a reusable PHP array containing four real portfolio items
- update the markup to use real screenshots, accessible links, and project metadata sourced from the portfolio page
- adjust homepage portfolio styles to support image thumbnails and add a visual tag for the project type

## Testing
- php -l index.php

------
https://chatgpt.com/codex/tasks/task_e_68def4428368832f8548b83631b412f7