### PR TITLE
Adjust portfolio reveal timing

### DIFF
--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -12,7 +12,10 @@
                 }
             });
         },
-        { threshold: 0.2 }
+        {
+            threshold: 0.05,
+            rootMargin: '0px 0px -10% 0px',
+        }
     );
 
     const revealTargets = document.querySelectorAll(


### PR DESCRIPTION
## Summary
- lower the IntersectionObserver threshold so portfolio items enter view immediately
- add a negative bottom root margin to trigger the reveal before items fully intersect

## Testing
- no automated tests were run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68df8b92d3b4832fbaddd8fe177b935b