### PR TITLE
Smooth portfolio fade-up animation

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -841,11 +841,24 @@ video {
 .reveal {
     opacity: 0;
     transform: translateY(30px);
-    transition: opacity 0.6s ease, transform 0.6s ease;
+    transition: opacity 0.75s cubic-bezier(0.22, 1, 0.36, 1), transform 0.75s cubic-bezier(0.22, 1, 0.36, 1);
+    transition-delay: var(--reveal-delay, 0s);
+    will-change: opacity, transform;
 }
 
 .reveal.in-view {
     opacity: 1;
+    transform: translateY(0);
+}
+
+.portfolio-item.reveal {
+    transform: translateY(40px);
+    filter: blur(12px);
+    transition: opacity 0.85s cubic-bezier(0.16, 1, 0.3, 1), transform 0.85s cubic-bezier(0.16, 1, 0.3, 1), filter 0.85s cubic-bezier(0.16, 1, 0.3, 1);
+}
+
+.portfolio-item.reveal.in-view {
+    filter: blur(0);
     transform: translateY(0);
 }
 

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -75,6 +75,11 @@
     if (portfolioItems.length > 0) {
         const earlyRevealCount = Math.min(portfolioItems.length, 4);
         const earlyRevealDelay = 200;
+        const revealInterval = 90;
+
+        portfolioItems.forEach((item, index) => {
+            item.style.setProperty('--reveal-delay', `${index * revealInterval}ms`);
+        });
 
         window.setTimeout(() => {
             portfolioItems.forEach((item, index) => {


### PR DESCRIPTION
## Summary
- smooth the reveal motion for portfolio cards with eased transitions and a soft blur fade
- stagger portfolio item animations via per-card delays set in JavaScript for a fluid entrance

## Testing
- php -S 0.0.0.0:8000

------
https://chatgpt.com/codex/tasks/task_e_68df8c2a67ac832f88611208db44a905